### PR TITLE
put the same env in each step into the configmap

### DIFF
--- a/engine/compiler/compiler_test.go
+++ b/engine/compiler/compiler_test.go
@@ -210,6 +210,8 @@ func testCompile(t *testing.T, source, golden string) *engine.Spec {
 	}
 
 	got := compiler.Compile(nocontext, args)
+	// skip: not need to compare envs
+	got.Envs = nil
 
 	raw, err := ioutil.ReadFile(golden)
 	if err != nil {

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -141,6 +141,7 @@ func toContainers(spec *Spec) []v1.Container {
 			},
 			VolumeMounts: toVolumeMounts(spec, s),
 			Env:          toEnv(spec, s),
+			EnvFrom:      toEnvFrom(spec, s),
 		}
 
 		containers = append(containers, container)
@@ -186,16 +187,24 @@ func toEnv(spec *Spec, step *Step) []v1.EnvVar {
 	return envVars
 }
 
-func toEnvFrom(step *Step) []v1.EnvFromSource {
-	return []v1.EnvFromSource{
-		{
-			SecretRef: &v1.SecretEnvSource{
-				LocalObjectReference: v1.LocalObjectReference{
-					Name: step.ID,
-				},
+func toEnvFrom(spec *Spec, step *Step) []v1.EnvFromSource {
+	var fromList []v1.EnvFromSource
+	fromList = append(fromList, v1.EnvFromSource{
+		ConfigMapRef: &v1.ConfigMapEnvSource{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: spec.PodSpec.Name,
 			},
 		},
-	}
+	})
+
+	// fromList = append(fromList, v1.EnvFromSource{
+	// 	SecretRef: &v1.SecretEnvSource{
+	// 		LocalObjectReference: v1.LocalObjectReference{
+	// 			Name: step.ID,
+	// 		},
+	// 	},
+	// })
+	return fromList
 }
 
 func toSecret(spec *Spec) *v1.Secret {
@@ -210,6 +219,15 @@ func toSecret(spec *Spec) *v1.Secret {
 		},
 		Type:       "Opaque",
 		StringData: stringData,
+	}
+}
+
+func toConfigMap(spec *Spec) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: spec.PodSpec.Name,
+		},
+		Data: spec.Envs,
 	}
 }
 

--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -76,6 +76,11 @@ func (k *Kubernetes) Setup(ctx context.Context, spec *Spec) error {
 		return err
 	}
 
+	_, err = k.client.CoreV1().ConfigMaps(spec.PodSpec.Namespace).Create(toConfigMap(spec))
+	if err != nil {
+		return err
+	}
+
 	_, err = k.client.CoreV1().Pods(spec.PodSpec.Namespace).Create(toPod(spec))
 	if err != nil {
 		return err
@@ -96,6 +101,11 @@ func (k *Kubernetes) Destroy(ctx context.Context, spec *Spec) error {
 	}
 
 	err := k.client.CoreV1().Secrets(spec.PodSpec.Namespace).Delete(spec.PodSpec.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	err = k.client.CoreV1().ConfigMaps(spec.PodSpec.Namespace).Delete(spec.PodSpec.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		result = multierror.Append(result, err)
 	}

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -15,6 +15,8 @@ type (
 		Volumes    []*Volume          `json:"volumes,omitempty"`
 		Secrets    map[string]*Secret `json:"secrets,omitempty"`
 		PullSecret *Secret            `json:"pull_secrets,omitempty"`
+		// Envs the same envs in multiple steps
+		Envs       map[string]string  `json:"envs,omitempty"`
 	}
 
 	// Step defines a pipeline step.


### PR DESCRIPTION
Write the `env` contained in each `container` independently into a `configmap`, and set to each container in the form of `envFrom.configmap` to improve the readability of the pod.

**Pod**

```yaml
- env:
    - name: PLUGIN_URLS
      value: http://XXXXX:8000/api/images/
    - name: PLUGIN_CONTENT_TYPE
      value: application/x-www-form-urlencoded
    - name: PLUGIN_TEMPLATE
      value: xxxx
    - name: KUBERNETES_NODE
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: spec.nodeName
    envFrom:
    - configMapRef:
        name: drone-qfgb8iiovj7a75nxmhpf
    image: drone/placeholder:1
    imagePullPolicy: IfNotPresent
    name: drone-wnc5urbsf3qecrpnax7e
```

**ConfigMap**

```yaml
apiVersion: v1
data:
  CI: "true"
  CI_BUILD_CREATED: "1573206404"
  CI_BUILD_EVENT: push
  CI_BUILD_FINISHED: "0"
  CI_BUILD_STATUS: pending
  CI_BUILD_TARGET: ""
  CI_COMMIT_AUTHOR: RenzHoly
  CI_COMMIT_BRANCH: master
  CI_COMMIT_MESSAGE: update
  CI_COMMIT_REF: refs/heads/master
  CI_COMMIT_SHA: fe3400271a09fdd753b2eecadc0307a58c2deff4
  CI_PARENT_BUILD_NUMBER: "0"
  DRONE: "true"
  DRONE_BRANCH: master
  DRONE_BUILD_ACTION: ""
......
kind: ConfigMap
metadata:
  creationTimestamp: "2019-11-08T09:46:49Z"
  name: drone-qfgb8iiovj7a75nxmhpf
  namespace: drone
  resourceVersion: "743334159"
  selfLink: /api/v1/namespaces/drone/configmaps/drone-qfgb8iiovj7a75nxmhpf
  uid: af6fb5c1-020c-11ea-90db-2aac168ca343
```