### PR TITLE
add rules file

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -101,22 +101,28 @@ func (c *compileCommand) run(*kingpin.ParseContext) error {
 
 	// compile the pipeline to an intermediate representation.
 	comp := &compiler.Compiler{
-		Environ:    c.Environ,
-		Labels:     c.Labels,
+		Environ: c.Environ,
+		Policies: []compiler.Policy{
+			{
+				Metadata: compiler.Metadata{
+					Labels: c.Labels,
+				},
+				Resources: compiler.Resources{
+					Limits: compiler.ResourceObject{
+						CPU:    c.LimitCPU,
+						Memory: c.LimitMemory,
+					},
+					Requests: compiler.ResourceObject{
+						CPU:    c.RequestCPU,
+						Memory: c.RequestMemory,
+					},
+				},
+			},
+		},
 		Privileged: append(c.Privileged, compiler.Privileged...),
 		Volumes:    c.Volumes,
 		Secret:     secret.Combine(),
 		Registry:   registry.Combine(),
-		Resources: compiler.Resources{
-			Limits: compiler.ResourceObject{
-				CPU:    c.LimitCPU,
-				Memory: c.LimitMemory,
-			},
-			Requests: compiler.ResourceObject{
-				CPU:    c.RequestCPU,
-				Memory: c.RequestMemory,
-			},
-		},
 	}
 
 	args := runtime.CompilerArgs{

--- a/command/daemon/policy.go
+++ b/command/daemon/policy.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/buildkite/yaml"
+)
+
+const Kind = "Policy"
+
+type Policy struct {
+	Kind string
+	Name string
+
+	Metadata       Metadata          `json:"metadata,omitempty"`
+	ServiceAccount string            `json:"service_account,omitempty" envconfig:"DRONE_SERVICE_ACCOUNT_DEFAULT"`
+	Images         Images            `json:"images,omitempty"`
+	Resources      Resources         `json:"resources,omitempty"`
+	NodeSelector   map[string]string `json:"node_selector,omitempty" envconfig:"DRONE_NODE_SELECTOR_DEFAULT"`
+	Tolerations    []Toleration      `json:"tolerations,omitempty"`
+
+	Match []string `json:"match,omitempty" default:"**"`
+}
+
+type Metadata struct {
+	Namespace   string            `json:"namespace,omitempty" envconfig:"DRONE_NAMESPACE_DEFAULT" default:"default"`
+	Labels      map[string]string `json:"labels,omitempty" envconfig:"DRONE_LABELS_DEFAULT"`
+	Annotations map[string]string `json:"annotations,omitempty" envconfig:"DRONE_ANNOTATIONS_DEFAULT"`
+}
+
+type Resources struct {
+	LimitCPU      int64     `envconfig:"DRONE_RESOURCE_LIMIT_CPU"`
+	LimitMemory   BytesSize `envconfig:"DRONE_RESOURCE_LIMIT_MEMORY"`
+	RequestCPU    int64     `envconfig:"DRONE_RESOURCE_REQUEST_CPU"`
+	RequestMemory BytesSize `envconfig:"DRONE_RESOURCE_REQUEST_MEMORY"`
+}
+
+type Toleration struct {
+	Effect            string `json:"effect,omitempty"`
+	Key               string `json:"key,omitempty"`
+	Operator          string `json:"operator,omitempty"`
+	TolerationSeconds *int   `json:"toleration_seconds,omitempty"`
+	Value             string `json:"value,omitempty"`
+}
+
+type Images struct {
+	Clone       string `envconfig:"DRONE_IMAGE_CLONE"`
+	Placeholder string `envconfig:"DRONE_IMAGE_PLACEHOLDER"`
+}
+
+func parsePolicies(b []byte) ([]Policy, error) {
+	buf := bytes.NewBuffer(b)
+	res := []Policy{}
+	dec := yaml.NewDecoder(buf)
+	for {
+		out := new(Policy)
+		err := dec.Decode(out)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if out.Kind == Kind {
+			res = append(res, *out)
+		}
+	}
+	return res, nil
+}

--- a/command/exec.go
+++ b/command/exec.go
@@ -120,13 +120,19 @@ func (c *execCommand) run(*kingpin.ParseContext) error {
 
 	// compile the pipeline to an intermediate representation.
 	comp := &compiler.Compiler{
-		Environ:    c.Environ,
-		Labels:     c.Labels,
+		Environ: c.Environ,
+		Policies: []compiler.Policy{
+			{
+				Metadata: compiler.Metadata{
+					Namespace: c.Namespace,
+					Labels:    c.Labels,
+				},
+			},
+		},
 		Privileged: append(c.Privileged, compiler.Privileged...),
 		Volumes:    c.Volumes,
 		Secret:     secret.StaticVars(c.Secrets),
 		Registry:   registry.Combine(),
-		Namespace:  c.Namespace,
 	}
 
 	args := runtime.CompilerArgs{

--- a/engine/compiler/testdata/graph.json
+++ b/engine/compiler/testdata/graph.json
@@ -3,7 +3,8 @@
   "pod_spec": {
     "name": "random",
     "labels": {},
-    "annotations": {}
+    "annotations": {},
+    "node_selector": {}
   },
   "steps": [
     {

--- a/engine/compiler/testdata/match.json
+++ b/engine/compiler/testdata/match.json
@@ -3,7 +3,8 @@
   "pod_spec": {
     "name": "random",
     "labels": {},
-    "annotations": {}
+    "annotations": {},
+    "node_selector": {}
   },
   "steps": [
     {

--- a/engine/compiler/testdata/noclone_graph.json
+++ b/engine/compiler/testdata/noclone_graph.json
@@ -3,7 +3,8 @@
   "pod_spec": {
     "name": "random",
     "labels": {},
-    "annotations": {}
+    "annotations": {},
+    "node_selector": {}
   },
   "steps": [
     {

--- a/engine/compiler/testdata/noclone_serial.json
+++ b/engine/compiler/testdata/noclone_serial.json
@@ -3,7 +3,8 @@
   "pod_spec": {
     "name": "random",
     "labels": {},
-    "annotations": {}
+    "annotations": {},
+    "node_selector": {}
   },
   "steps": [
     {

--- a/engine/compiler/testdata/run_always.json
+++ b/engine/compiler/testdata/run_always.json
@@ -3,7 +3,8 @@
   "pod_spec": {
     "name": "random",
     "labels": {},
-    "annotations": {}
+    "annotations": {},
+    "node_selector": {}
   },
   "steps": [
     {

--- a/engine/compiler/testdata/run_failure.json
+++ b/engine/compiler/testdata/run_failure.json
@@ -3,7 +3,8 @@
   "pod_spec": {
     "name": "random",
     "labels": {},
-    "annotations": {}
+    "annotations": {},
+    "node_selector": {}
   },
   "steps": [
     {

--- a/engine/compiler/testdata/serial.json
+++ b/engine/compiler/testdata/serial.json
@@ -3,7 +3,8 @@
   "pod_spec": {
     "name": "random",
     "labels": {},
-    "annotations": {}
+    "annotations": {},
+    "node_selector": {}
   },
   "steps": [
     {

--- a/engine/compiler/testdata/service.json
+++ b/engine/compiler/testdata/service.json
@@ -2,6 +2,7 @@
   "pod_spec": {
     "name": "random",
     "annotations": {},
+    "node_selector": {},
     "labels": {},
     "host_aliases": [
       {

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90


### PR DESCRIPTION
This PR adds a rules file that defines default settings based on the repo slug. An example rules file would look something like this:

```
- match:  
  - foo/*
  enforce: true
  metadata:
    namespace: foo
    labels:
      group: foo
    annotations:
      group: foo
  service_account: foo
  images:
    clone: alpine/git:latest
    placeholder: drone/placeholder:latest
  resources:
    requests:
      cpu: 1
      memory: 1Gi  
    limits:
      cpu: 1
      memory: 1Gi      
  nodeSelector:
   nodeGroup: foo
  tolerations:
  - key: nodeGroup
    value: foo
    operator: Exists

- match:
  - **
  enforce: false
  metadata
    namespace: default
```

We can then add linting for the rules with enforce enabled for things like: 
* `namespace`
* `service_account `
* `nodeSelector`
* `tolerations`, 
* maximum `resources`.

`Images` would override the builtin defaults. 

`labels` and `annotations` would be added to the user defined labels and annotations.