### PR TITLE
Add dns_config parameter

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -242,7 +242,21 @@ func (c *Compiler) Compile(ctx context.Context, args Args) *engine.Spec {
 	if spec.PodSpec.ServiceAccountName == "" {
 		spec.PodSpec.ServiceAccountName = c.ServiceAccount
 	}
+	// add dns_config
+	if len(args.Pipeline.DnsConfig.Nameservers) > 0 {
+		spec.PodSpec.DnsConfig.Nameservers = args.Pipeline.DnsConfig.Nameservers
+	}
 
+	if len(args.Pipeline.DnsConfig.Searches) > 0 {
+		spec.PodSpec.DnsConfig.Searches = args.Pipeline.DnsConfig.Searches
+	}
+
+	for _, dnsconfig := range args.Pipeline.DnsConfig.Options {
+		spec.PodSpec.DnsConfig.Options = append(spec.PodSpec.DnsConfig.Options, engine.DNSConfigOptions{
+			Name:  dnsconfig.Name,
+			Value: dnsconfig.Value,
+		})
+	}
 	// add tolerations
 	for _, toleration := range args.Pipeline.Tolerations {
 		spec.PodSpec.Tolerations = append(spec.PodSpec.Tolerations, engine.Toleration{

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -30,7 +30,26 @@ func toPod(spec *Spec) *v1.Pod {
 			Tolerations:        toTolerations(spec),
 			ImagePullSecrets:   toImagePullSecrets(spec),
 			HostAliases:        toHostAliases(spec),
+			DNSConfig:          toDnsConfig(spec),
 		},
+	}
+}
+
+func toDnsConfig(spec *Spec) *v1.PodDNSConfig {
+	var dnsOptions []v1.PodDNSConfigOption
+	if len(spec.PodSpec.DnsConfig.Options) > 0 {
+		for _, option := range spec.PodSpec.DnsConfig.Options {
+			o := v1.PodDNSConfigOption{
+				Name:  option.Name,
+				Value: option.Value,
+			}
+			dnsOptions = append(dnsOptions, o)
+		}
+	}
+	return &v1.PodDNSConfig{
+		Nameservers: spec.PodSpec.DnsConfig.Nameservers,
+		Searches:    spec.PodSpec.DnsConfig.Searches,
+		Options:     dnsOptions,
 	}
 }
 

--- a/engine/resource/parser_test.go
+++ b/engine/resource/parser_test.go
@@ -19,6 +19,8 @@ func TestParse(t *testing.T) {
 		return
 	}
 
+	var dns_config_ptr string = "1"
+
 	want := []manifest.Resource{
 		&manifest.Signature{
 			Kind: "signature",
@@ -53,6 +55,16 @@ func TestParse(t *testing.T) {
 			},
 			Clone: manifest.Clone{
 				Depth: 50,
+			},
+			DnsConfig: DnsConfig{
+				Nameservers: []string{"1.1.1.1"},
+				Searches:    []string{"test.local"},
+				Options: []DNSConfigOptions{
+					{
+						Name:  "ndots",
+						Value: &dns_config_ptr,
+					},
+				},
 			},
 			NodeSelector: map[string]string{"foo": "bar"},
 			PullSecrets:  []string{"dockerconfigjson"},

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -48,6 +48,7 @@ type Pipeline struct {
 	NodeSelector       map[string]string `json:"node_selector,omitempty"        yaml:"node_selector"`
 	ServiceAccountName string            `json:"service_account_name,omitempty" yaml:"service_account_name"`
 	Tolerations        []Toleration      `json:"tolerations,omitempty"`
+	DnsConfig          DnsConfig         `json:"dns_config,omitempty" yaml:"dns_config"`
 }
 
 // GetVersion returns the resource version.
@@ -94,6 +95,17 @@ type (
 		Namespace   string            `json:"namespace,omitempty"`
 		Annotations map[string]string `json:"annotations,omitempty"`
 		Labels      map[string]string `json:"labels,omitempty"`
+	}
+	// DnsConfig defines Kubernetes pod dnsConfig
+	DnsConfig struct {
+		Nameservers []string           `json:"nameservers,omitempty"`
+		Searches    []string           `json:"searches,omitempty"`
+		Options     []DNSConfigOptions `json:"options,omitempty"`
+	}
+
+	DNSConfigOptions struct {
+		Name  string  `json:"name,omitempty"`
+		Value *string `json:"value,omitempty" yaml:"value"`
 	}
 
 	// Toleration defines Kubernetes pod tolerations

--- a/engine/resource/testdata/manifest.yml
+++ b/engine/resource/testdata/manifest.yml
@@ -31,6 +31,15 @@ workspace:
 clone:
   depth: 50
 
+dns_config:
+  nameservers:
+    - 1.1.1.1
+  searches:
+    - test.local
+  options:
+    - name: ndots
+      value: 1
+
 steps:
 - name: build
   image: golang

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -136,6 +136,7 @@ type (
 		Tolerations        []Toleration      `json:"tolerations,omitempty"`
 		ServiceAccountName string            `json:"service_account_name,omitempty"`
 		HostAliases        []HostAlias       `json:"host_aliases,omitempty"`
+		DnsConfig          DnsConfig         `json:"dns_config,omitempty"`
 	}
 
 	// HostAlias ...
@@ -151,5 +152,16 @@ type (
 		Operator          string `json:"operator,omitempty"`
 		TolerationSeconds *int   `json:"toleration_seconds,omitempty"`
 		Value             string `json:"value,omitempty"`
+	}
+	// DnsConfig
+	DnsConfig struct {
+		Nameservers []string           `json:"nameservers,omitempty"`
+		Searches    []string           `json:"searches,omitempty"`
+		Options     []DNSConfigOptions `json:"options,omitempty"`
+	}
+
+	DNSConfigOptions struct {
+		Name  string  `json:"name,omitempty"`
+		Value *string `json:"value,omitempty"`
 	}
 )


### PR DESCRIPTION
Adding `dns_config` parameter for use in the pipeline. [Kubernetes Docs](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config).  
The solution to the problem with resolving names inside containers and [Kubernetes DNS performance](https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html).  
**Use:**  
```yaml
dns_config:
   options:
    - name: ndots
      value: 1
```
```yaml
dns_config:
  nameservers:
    - 1.1.1.1
  searches:
    - test.local
  options:
    - name: ndots
      value: 1
```
```sh
cat /etc/resolv.conf
#####################
nameserver 10.96.0.10
nameserver 1.1.1.1
search cicd.svc.cluster.local svc.cluster.local cluster.local test.local
options ndots:1
```