### PR TITLE
Resolve waitForReady issue in runtimes other than docker

### DIFF
--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
+	"github.com/drone-runners/drone-runner-kube/internal/docker/image"
 	"github.com/drone/runner-go/livelog"
 	"github.com/hashicorp/go-multierror"
 	v1 "k8s.io/api/core/v1"
@@ -182,10 +182,7 @@ func (k *Kubernetes) waitForReady(ctx context.Context, spec *Spec, step *Step) e
 				if cs.Name != step.ID {
 					continue
 				}
-				if strings.HasSuffix(cs.Image, step.Placeholder) {
-					continue
-				}
-				if (cs.State.Running != nil) || (cs.State.Terminated != nil) {
+				if (!image.Match(cs.Image, step.Placeholder) && cs.State.Running != nil) || (cs.State.Terminated != nil) {
 					return true, nil
 				}
 			}

--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/drone/runner-go/livelog"
@@ -181,7 +182,10 @@ func (k *Kubernetes) waitForReady(ctx context.Context, spec *Spec, step *Step) e
 				if cs.Name != step.ID {
 					continue
 				}
-				if (cs.Image != step.Placeholder && cs.State.Running != nil) || (cs.State.Terminated != nil) {
+				if strings.HasSuffix(cs.Image, step.Placeholder) {
+					continue
+				}
+				if (cs.State.Running != nil) || (cs.State.Terminated != nil) {
 					return true, nil
 				}
 			}


### PR DESCRIPTION
Runtimes such as containerd (not sure about CRI-O) report the image for the placeholder as a fully-qualified name: `docker.io/drone/placeholder:1`

This caused the waitForReady function to return prematurely, causing the log streamer to tail the placeholder container, rather than the actual job. When the placeholder container closes, so too does the log stream.

An alternate approach is to simply specify the fully-qualified image ID in the environment variable `DRONE_IMAGE_PLACEHOLDER`, though this seems like more effort for the end user?

One last approach would be to repeatedly tail the container until the step completes (which would be more failure resistant should the connection to the API server drop out..)