### PR TITLE
toTolerations: Copy toleration key

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,7 +5,7 @@
 
 3. Build binaries
 
-    sh scripts/build_all.sh
+    ./scripts/build.sh
 
 4. Build images
 

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -246,6 +246,7 @@ func (c *Compiler) Compile(ctx context.Context, args Args) *engine.Spec {
 	// add tolerations
 	for _, toleration := range args.Pipeline.Tolerations {
 		spec.PodSpec.Tolerations = append(spec.PodSpec.Tolerations, engine.Toleration{
+			Key:               toleration.Key,
 			Operator:          toleration.Operator,
 			Effect:            toleration.Effect,
 			TolerationSeconds: toleration.TolerationSeconds,

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -51,6 +51,7 @@ func toTolerations(spec *Spec) []v1.Toleration {
 	var tolerations []v1.Toleration
 	for _, toleration := range spec.PodSpec.Tolerations {
 		t := v1.Toleration{
+			Key:      toleration.Key,
 			Operator: v1.TolerationOperator(toleration.Operator),
 			Effect:   v1.TaintEffect(toleration.Effect),
 			Value:    toleration.Value,


### PR DESCRIPTION
Fixes the following pod spec error:
```
spec.tolerations[0].operator: Invalid value: "Equal": operator must be Exists when `key` is empty, which means "match all values and all keys"
```