### PR TITLE
support DRONE_RUNNER_VOLUMES

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -30,6 +30,7 @@ type compileCommand struct {
 
 	Source        *os.File
 	Privileged    []string
+	Volumes       map[string]string
 	Environ       map[string]string
 	Labels        map[string]string
 	Secrets       map[string]string
@@ -103,6 +104,7 @@ func (c *compileCommand) run(*kingpin.ParseContext) error {
 		Environ:    c.Environ,
 		Labels:     c.Labels,
 		Privileged: append(c.Privileged, compiler.Privileged...),
+		Volumes:    c.Volumes,
 		Secret:     secret.Combine(),
 		Registry:   registry.Combine(),
 		Resources: compiler.Resources{
@@ -147,6 +149,7 @@ func registerCompile(app *kingpin.Application) {
 	c.Environ = map[string]string{}
 	c.Secrets = map[string]string{}
 	c.Labels = map[string]string{}
+	c.Volumes = map[string]string{}
 
 	cmd := app.Command("compile", "compile the yaml file").
 		Action(c.run)
@@ -166,6 +169,9 @@ func registerCompile(app *kingpin.Application) {
 
 	cmd.Flag("labels", "container labels").
 		StringMapVar(&c.Labels)
+
+	cmd.Flag("volumes", "container volumes").
+		StringMapVar(&c.Volumes)
 
 	cmd.Flag("privileged", "privileged docker images").
 		StringsVar(&c.Privileged)

--- a/command/daemon/config.go
+++ b/command/daemon/config.go
@@ -52,6 +52,7 @@ type Config struct {
 		EnvFile    string            `envconfig:"DRONE_RUNNER_ENV_FILE"`
 		Secrets    map[string]string `envconfig:"DRONE_RUNNER_SECRETS"`
 		Labels     map[string]string `envconfig:"DRONE_RUNNER_LABELS"`
+		Volumes    map[string]string `envconfig:"DRONE_RUNNER_VOLUMES"`
 		Privileged []string          `envconfig:"DRONE_RUNNER_PRIVILEGED_IMAGES"`
 	}
 

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -108,6 +108,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 				Cloner:         config.Images.Clone,
 				Placeholder:    config.Images.Placeholder,
 				Environ:        config.Runner.Environ,
+				Volumes:        config.Runner.Volumes,
 				Namespace:      config.Namespace.Default,
 				Labels:         config.Labels.Default,
 				Annotations:    config.Annotations.Default,

--- a/command/exec.go
+++ b/command/exec.go
@@ -43,6 +43,7 @@ type execCommand struct {
 	Include    []string
 	Exclude    []string
 	Privileged []string
+	Volumes    map[string]string
 	Environ    map[string]string
 	Labels     map[string]string
 	Secrets    map[string]string
@@ -123,6 +124,7 @@ func (c *execCommand) run(*kingpin.ParseContext) error {
 		Environ:    c.Environ,
 		Labels:     c.Labels,
 		Privileged: append(c.Privileged, compiler.Privileged...),
+		Volumes:    c.Volumes,
 		Secret:     secret.StaticVars(c.Secrets),
 		Registry:   registry.Combine(),
 		Namespace:  c.Namespace,
@@ -260,6 +262,7 @@ func registerExec(app *kingpin.Application) {
 	c.Environ = map[string]string{}
 	c.Secrets = map[string]string{}
 	c.Labels = map[string]string{}
+	c.Volumes = map[string]string{}
 
 	cmd := app.Command("exec", "executes a pipeline").
 		Action(c.run)
@@ -285,6 +288,9 @@ func registerExec(app *kingpin.Application) {
 
 	cmd.Flag("labels", "container labels").
 		StringMapVar(&c.Labels)
+
+	cmd.Flag("volumes", "container volumes").
+		StringMapVar(&c.Volumes)
 
 	cmd.Flag("privileged", "privileged docker images").
 		StringsVar(&c.Privileged)

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -7,6 +7,7 @@ package compiler
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -116,6 +117,10 @@ type (
 		// Privileged provides a list of docker images that
 		// are always privileged.
 		Privileged []string
+
+		// Volumes provides a set of volumes that should be
+		// mounted to each pipeline container.
+		Volumes map[string]string
 
 		// Secret returns a named secret value that can be injected
 		// into the pipeline step.
@@ -474,6 +479,30 @@ func (c *Compiler) Compile(ctx context.Context, args Args) *engine.Spec {
 		spec.PullSecret = &engine.Secret{
 			Name: random(),
 			Data: auths.Encode(creds...),
+		}
+	}
+
+	// append global volumes to the steps.
+	for k, v := range c.Volumes {
+		id := random()
+		ro := strings.HasSuffix(v, ":ro")
+		v = strings.TrimSuffix(v, ":ro")
+		volume := &engine.Volume{
+			HostPath: &engine.VolumeHostPath{
+				ID:       id,
+				Name:     id,
+				Path:     k,
+				ReadOnly: ro,
+			},
+		}
+		spec.Volumes = append(spec.Volumes, volume)
+		for _, step := range spec.Steps {
+			mount := &engine.VolumeMount{
+				Name: id,
+				Path: v,
+				ReadOnly: ro,
+			}
+			step.Volumes = append(step.Volumes, mount)
 		}
 	}
 

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -489,17 +489,16 @@ func (c *Compiler) Compile(ctx context.Context, args Args) *engine.Spec {
 		v = strings.TrimSuffix(v, ":ro")
 		volume := &engine.Volume{
 			HostPath: &engine.VolumeHostPath{
-				ID:       id,
-				Name:     id,
-				Path:     k,
-				ReadOnly: ro,
+				ID:   id,
+				Name: id,
+				Path: k,
 			},
 		}
 		spec.Volumes = append(spec.Volumes, volume)
 		for _, step := range spec.Steps {
 			mount := &engine.VolumeMount{
-				Name: id,
-				Path: v,
+				Name:     id,
+				Path:     v,
 				ReadOnly: ro,
 			}
 			step.Volumes = append(step.Volumes, mount)

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -266,6 +266,7 @@ func toVolumeMounts(spec *Spec, step *Step) []v1.VolumeMount {
 		volumeMounts = append(volumeMounts, v1.VolumeMount{
 			Name:      id,
 			MountPath: v.Path,
+			ReadOnly:  v.ReadOnly,
 		})
 	}
 

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -80,8 +80,9 @@ type (
 	// VolumeMount describes a mounting of a Volume
 	// within a container.
 	VolumeMount struct {
-		Name string `json:"name,omitempty"`
-		Path string `json:"path,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Path     string `json:"path,omitempty"`
+		ReadOnly bool   `json:"read_only,omitempty"`
 	}
 
 	// VolumeEmptyDir mounts a temporary directory from the
@@ -97,9 +98,10 @@ type (
 	// VolumeHostPath mounts a file or directory from the
 	// host node's filesystem into your container.
 	VolumeHostPath struct {
-		ID   string `json:"id,omitempty"`
-		Name string `json:"name,omitempty"`
-		Path string `json:"path,omitempty"`
+		ID       string `json:"id,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Path     string `json:"path,omitempty"`
+		ReadOnly bool   `json:"read_only,omitempty"`
 	}
 	// VolumeDownwardAPI ...
 	VolumeDownwardAPI struct {

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -98,10 +98,9 @@ type (
 	// VolumeHostPath mounts a file or directory from the
 	// host node's filesystem into your container.
 	VolumeHostPath struct {
-		ID       string `json:"id,omitempty"`
-		Name     string `json:"name,omitempty"`
-		Path     string `json:"path,omitempty"`
-		ReadOnly bool   `json:"read_only,omitempty"`
+		ID   string `json:"id,omitempty"`
+		Name string `json:"name,omitempty"`
+		Path string `json:"path,omitempty"`
 	}
 	// VolumeDownwardAPI ...
 	VolumeDownwardAPI struct {


### PR DESCRIPTION
This implements [DRONE_RUNNER_VOLUMES](https://docs.drone.io/runner/docker/configuration/reference/drone-runner-volumes/) for the kube runner (it's already implemented in the docker runner). Example for the [kube runner helm chart](https://github.com/drone/charts/tree/master/charts/drone-runner-kube):
```
env:
  DRONE_RUNNER_VOLUMES: /opt:/opt
```

Issues: At the moment you can't enforce read-only with `DRONE_RUNNER_VOLUMES: /opt:/opt:ro`. This depends on https://github.com/kelseyhightower/envconfig/pull/133.

Some history: https://discourse.drone.io/t/plugins-github-release-ca-certificates-with-ghe/6917