### PR TITLE
feat: add user & group to pipeline step definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `User` and `Group` fields to **step** definition to change the default user and group of a container.

--- a/engine/compiler/step.go
+++ b/engine/compiler/step.go
@@ -32,6 +32,7 @@ func createStep(spec *resource.Pipeline, src *resource.Step) *engine.Step {
 		Privileged:   src.Privileged,
 		Pull:         convertPullPolicy(src.Pull),
 		User:         src.User,
+		Group:        src.Group,
 		Resources:    convertResources(src.Resources),
 		Secrets:      convertSecretEnv(src.Environment),
 		WorkingDir:   src.WorkingDir,

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -157,11 +157,9 @@ func toContainers(spec *Spec) []v1.Container {
 			ImagePullPolicy: toPullPolicy(s.Pull),
 			WorkingDir:      s.WorkingDir,
 			Resources:       toResources(s.Resources),
-			SecurityContext: &v1.SecurityContext{
-				Privileged: boolptr(s.Privileged),
-			},
-			VolumeMounts: toVolumeMounts(spec, s),
-			Env:          toEnv(spec, s),
+			SecurityContext: toSecurityContext(s),
+			VolumeMounts:    toVolumeMounts(spec, s),
+			Env:             toEnv(spec, s),
 		}
 
 		containers = append(containers, container)
@@ -298,6 +296,14 @@ func toResources(src Resources) v1.ResourceRequirements {
 		}
 	}
 	return dst
+}
+
+func toSecurityContext(s *Step) *v1.SecurityContext {
+	return &v1.SecurityContext{
+		Privileged: boolptr(s.Privileged),
+		RunAsUser: s.User,
+		RunAsGroup: s.Group,
+	}
 }
 
 // LookupVolume is a helper function that will lookup

--- a/engine/convert_test.go
+++ b/engine/convert_test.go
@@ -3,3 +3,30 @@
 // that can be found in the LICENSE file.
 
 package engine
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestSecurityContext(t *testing.T)  {
+	test := &Step{
+		Privileged: true,
+		User: int64ptr(1000),
+		Group: int64ptr(1000),
+	}
+
+	want := v1.SecurityContext{
+		Privileged: boolptr(true),
+		RunAsUser:  int64ptr(1000),
+		RunAsGroup: int64ptr(1000),
+	}
+
+	got := toSecurityContext(test)
+
+	failed :=  *want.Privileged != *got.Privileged || *want.RunAsUser != *got.RunAsUser || *want.RunAsGroup != *got.RunAsGroup
+
+	if failed {
+		t.Error("security context was not converted to expected values")
+	}
+}

--- a/engine/convert_test.go
+++ b/engine/convert_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 )
 
-func TestSecurityContext(t *testing.T)  {
+func TestSecurityContext(t *testing.T) {
 	test := &Step{
 		Privileged: true,
-		User: int64ptr(1000),
-		Group: int64ptr(1000),
+		User:       int64ptr(1000),
+		Group:      int64ptr(1000),
 	}
 
 	want := v1.SecurityContext{
@@ -24,7 +24,7 @@ func TestSecurityContext(t *testing.T)  {
 
 	got := toSecurityContext(test)
 
-	failed :=  *want.Privileged != *got.Privileged || *want.RunAsUser != *got.RunAsUser || *want.RunAsGroup != *got.RunAsGroup
+	failed := *want.Privileged != *got.Privileged || *want.RunAsUser != *got.RunAsUser || *want.RunAsGroup != *got.RunAsGroup
 
 	if failed {
 		t.Error("security context was not converted to expected values")

--- a/engine/resource/parser_test.go
+++ b/engine/resource/parser_test.go
@@ -118,6 +118,39 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseWithUserGroup(t *testing.T)  {
+	got, err := manifest.ParseFile("testdata/manifest-with-user-group.yml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := []manifest.Resource{
+		&Pipeline{
+			Kind:    "pipeline",
+			Type:    "kubernetes",
+			Name:    "default",
+			Version: "1",
+			Steps: []*Step{
+				{
+					Name:      "build",
+					Image:     "golang",
+					Commands: []string{
+						"go build",
+					},
+					User: int64ptr(1000),
+					Group: int64ptr(1000),
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got.Resources, want); diff != "" {
+		t.Error("manifest step does not have proper user/group values")
+		t.Log(diff)
+	}
+
+}
 func TestParseErr(t *testing.T) {
 	_, err := manifest.ParseFile("testdata/malformed.yml")
 	if err == nil {
@@ -192,4 +225,8 @@ func TestLint(t *testing.T) {
 	if err := lint(p); err == nil {
 		t.Errorf("Expect error when empty name")
 	}
+}
+
+func int64ptr(x int64) *int64 {
+	return &x
 }

--- a/engine/resource/parser_test.go
+++ b/engine/resource/parser_test.go
@@ -118,7 +118,7 @@ func TestParse(t *testing.T) {
 	}
 }
 
-func TestParseWithUserGroup(t *testing.T)  {
+func TestParseWithUserGroup(t *testing.T) {
 	got, err := manifest.ParseFile("testdata/manifest-with-user-group.yml")
 	if err != nil {
 		t.Error(err)
@@ -133,12 +133,12 @@ func TestParseWithUserGroup(t *testing.T)  {
 			Version: "1",
 			Steps: []*Step{
 				{
-					Name:      "build",
-					Image:     "golang",
+					Name:  "build",
+					Image: "golang",
 					Commands: []string{
 						"go build",
 					},
-					User: int64ptr(1000),
+					User:  int64ptr(1000),
 					Group: int64ptr(1000),
 				},
 			},
@@ -149,8 +149,8 @@ func TestParseWithUserGroup(t *testing.T)  {
 		t.Error("manifest step does not have proper user/group values")
 		t.Log(diff)
 	}
-
 }
+
 func TestParseErr(t *testing.T) {
 	_, err := manifest.ParseFile("testdata/malformed.yml")
 	if err == nil {

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -133,7 +133,8 @@ type (
 		Resources   Resources                      `json:"resource,omitempty"`
 		Settings    map[string]*manifest.Parameter `json:"settings,omitempty"`
 		Shell       string                         `json:"shell,omitempty"`
-		User        string                         `json:"user,omitempty"`
+		User        *int64                         `json:"user,omitempty"`
+		Group       *int64                         `json:"group,omitempty"`
 		Volumes     []*VolumeMount                 `json:"volumes,omitempty"`
 		When        manifest.Conditions            `json:"when,omitempty"`
 		WorkingDir  string                         `json:"working_dir,omitempty" yaml:"working_dir"`

--- a/engine/resource/testdata/manifest-with-user-group.yml
+++ b/engine/resource/testdata/manifest-with-user-group.yml
@@ -1,0 +1,15 @@
+---
+kind: pipeline
+type: kubernetes
+name: default
+version: 1
+
+steps:
+- name: build
+  image: golang
+  commands:
+  - go build
+  user: 1000
+  group: 1000
+
+...

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -36,7 +36,8 @@ type (
 		Pull         PullPolicy        `json:"pull,omitempty"`
 		RunPolicy    RunPolicy         `json:"run_policy,omitempty"`
 		Secrets      []*SecretVar      `json:"secrets,omitempty"`
-		User         string            `json:"user,omitempty"`
+		User         *int64            `json:"user,omitempty"`
+		Group        *int64            `json:"group,omitempty"`
 		Volumes      []*VolumeMount    `json:"volumes,omitempty"`
 		WorkingDir   string            `json:"working_dir,omitempty"`
 	}


### PR DESCRIPTION
This PR follows up on the [feature discussion on Discourse](https://discourse.drone.io/t/kube-runner-add-runasuser-and-runasgroup-to-pipeline-step-definition/7109)

PR Summary:
- Added `user` and `group` fields to `Step` definition
- Added relevant tests
- Updated Changelog

Notes:
- The `user` field already existed, but it had `string` type. Since `k8s` API only accepts `int`, this had to be changed. This will result in a break in backward compatibility, _so this change needs to highlighted in next release notes._


These changes have been tested against `Kubernetes Cluster v1.15`