### PR TITLE
engine/engine_impl.go: Add a mutex around pod image updates for step progress.

### DIFF
--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -40,7 +40,7 @@ type Kubernetes struct {
 	client *kubernetes.Clientset
 	// Protects concurrent calls to PodInterface.Update to reduce the
 	// chance of a self-inflicted concurrent modification error.
-	updateMutex *sync.Mutex
+	updateMutex sync.Mutex
 }
 
 // NewFromConfig returns a new out-of-cluster engine.
@@ -57,8 +57,7 @@ func NewFromConfig(path string) (*Kubernetes, error) {
 		return nil, err
 	}
 	return &Kubernetes{
-		client:      clientset,
-		updateMutex: &sync.Mutex{},
+		client: clientset,
 	}, nil
 }
 
@@ -75,8 +74,7 @@ func NewInCluster() (*Kubernetes, error) {
 		return nil, err
 	}
 	return &Kubernetes{
-		client:      clientset,
-		updateMutex: &sync.Mutex{},
+		client: clientset,
 	}, nil
 }
 

--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -253,7 +253,7 @@ func (k *Kubernetes) tail(ctx context.Context, spec *Spec, step *Step, output io
 func (k *Kubernetes) start(spec *Spec, step *Step) error {
 	err := retry.RetryOnConflict(backoff, func() error {
 		// We protect this read/modify/write with a mutex to reduce the
-		// change of a self-inflicted concurrent modification error
+		// chance of a self-inflicted concurrent modification error
 		// when a DAG in a pipeline is fanning out and we have a lot of
 		// steps to Start at once.
 		k.updateMutex.Lock()

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -4,6 +4,10 @@
 
 package engine
 
+import (
+	"sync"
+)
+
 type (
 	// Spec provides the pipeline spec. This provides the
 	// required instructions for reproducible pipeline
@@ -15,6 +19,10 @@ type (
 		Volumes    []*Volume          `json:"volumes,omitempty"`
 		Secrets    map[string]*Secret `json:"secrets,omitempty"`
 		PullSecret *Secret            `json:"pull_secrets,omitempty"`
+		// Runtime field to gate updating of the pod that this pipeline
+		// is running on. Helps to avoid self-inflicted 409 Conflict
+		// responses from the kubernetes api server.
+		podUpdateMutex sync.Mutex
 	}
 
 	// Step defines a pipeline step.


### PR DESCRIPTION
When a pipeline fans out a DAG, concurrent calls are made to (*Kubernetes).Run
to start each step in parallel. But starting a step requires a
Read/Modify/Write loop to the Kubernetes API, and so updates are highly likely
to fail with a concurrent modification error. A user encountered this behavior
here[1], and it's easy to reproduce by creating a pipeline with high fan out.

This commit adds a mutex around the Read/Modify/Write loop in
(*Kubernetes).start. We know that concurrent modifications from the single
process will cause failures, so there is no reason to dispatch them
concurrently.

This commit also changes the current backoff parameters (5 max tries, .1
jitter factor) to be a little more robust. In local testing, even with the
mutex, concurrent modification errors were still possible but were much rarer.

1: https://discourse.drone.io/t/kube-runner-limitations/6853