### PR TITLE
Use the pipeline's shell property in the pod

### DIFF
--- a/engine/compiler/script.go
+++ b/engine/compiler/script.go
@@ -50,7 +50,12 @@ func setupScriptWindows(commands []string, dst *engine.Step) {
 // helper function configures the pipeline script for the
 // linux operating system.
 func setupScriptPosix(commands []string, dst *engine.Step) {
-	dst.Entrypoint = []string{"/bin/sh", "-c"}
-	dst.Command = []string{`echo "$DRONE_SCRIPT" | /bin/sh`}
+	if dst.Shell == "" {
+		dst.Entrypoint = []string{"/bin/sh", "-c"}
+		dst.Command = []string{`echo "$DRONE_SCRIPT" | /bin/sh`}
+	} else {
+		dst.Entrypoint = []string{dst.Shell, "-c"}
+		dst.Command = []string{`echo "$DRONE_SCRIPT" | ` + dst.Shell}
+	}
 	dst.Envs["DRONE_SCRIPT"] = shell.Script(commands)
 }

--- a/engine/compiler/step.go
+++ b/engine/compiler/step.go
@@ -36,6 +36,7 @@ func createStep(spec *resource.Pipeline, src *resource.Step) *engine.Step {
 		Group:        src.Group,
 		Resources:    convertResources(src.Resources),
 		Secrets:      convertSecretEnv(src.Environment),
+		Shell:        src.Shell,
 		WorkingDir:   src.WorkingDir,
 	}
 

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -53,6 +53,7 @@ type (
 		Pull         PullPolicy        `json:"pull,omitempty"`
 		RunPolicy    runtime.RunPolicy `json:"run_policy,omitempty"`
 		Secrets      []*SecretVar      `json:"secrets,omitempty"`
+		Shell        string            `json:"shell,omitempty"`
 		SpecSecrets  []*Secret         `json:"spec_secrets,omitempty"`
 		User         *int64            `json:"user,omitempty"`
 		Group        *int64            `json:"group,omitempty"`


### PR DESCRIPTION
I want to override `/bin/sh` with a shell of my choice. Does this code look like a good start? How would I write a good test for this? One wrinkle, I can't get it working on my side, the pod says it can't find the `/bin/bash` executable, which is odd. Any tips?