### PR TITLE
Add env variable "DRONE_STEP_NAME" for every step.

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -394,6 +394,7 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 	for _, src := range pipeline.Steps {
 		dst := createStep(pipeline, src)
 		dst.Envs = environ.Combine(envs, dst.Envs)
+		dst.Envs["DRONE_STEP_NAME"] = src.Name
 		dst.Volumes = append(dst.Volumes, workMount, statusMount)
 		setupScript(src, dst, os)
 		setupWorkdir(src, dst, workspace)


### PR DESCRIPTION
I can's find the env variable "DRONE_STEP_NAME" during building my project some days ago.

So I raise an issue here: https://discourse.drone.io/t/drone-kube-runner-has-no-drone-step-name-env-variable-during-building/7874

But nobody answered me. So I just try to fix it.