### PR TITLE
add option to override dnspolicy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ drone-runner-kube.exe
 release/*
 .env
 .docker
+.idea
 TODO.md
 NOTES.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `User` and `Group` fields to **step** definition to change the default user and group of a container.
+- Add override for podspec dnsPolicy

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -244,6 +244,11 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 			Value: dnsconfig.Value,
 		})
 	}
+	// add dns_policy
+	if len(pipeline.DnsPolicy.Policy) > 0 {
+		spec.PodSpec.DnsPolicy.Policy = pipeline.DnsPolicy.Policy
+	}
+
 	// add tolerations
 	for _, toleration := range pipeline.Tolerations {
 		spec.PodSpec.Tolerations = append(spec.PodSpec.Tolerations, engine.Toleration{

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -31,6 +31,7 @@ func toPod(spec *Spec) *v1.Pod {
 			ImagePullSecrets:   toImagePullSecrets(spec),
 			HostAliases:        toHostAliases(spec),
 			DNSConfig:          toDnsConfig(spec),
+			DNSPolicy:          toDnsPolicy(spec),
 		},
 	}
 }
@@ -51,6 +52,10 @@ func toDnsConfig(spec *Spec) *v1.PodDNSConfig {
 		Searches:    spec.PodSpec.DnsConfig.Searches,
 		Options:     dnsOptions,
 	}
+}
+
+func toDnsPolicy(spec *Spec) v1.DNSPolicy {
+	return v1.DNSPolicy(spec.PodSpec.DnsPolicy.Policy)
 }
 
 func toHostAliases(spec *Spec) []v1.HostAlias {

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -4,7 +4,9 @@
 
 package resource
 
-import "github.com/drone/runner-go/manifest"
+import (
+	"github.com/drone/runner-go/manifest"
+)
 
 var (
 	_ manifest.Resource          = (*Pipeline)(nil)
@@ -49,6 +51,7 @@ type Pipeline struct {
 	ServiceAccountName string            `json:"service_account_name,omitempty" yaml:"service_account_name"`
 	Tolerations        []Toleration      `json:"tolerations,omitempty"`
 	DnsConfig          DnsConfig         `json:"dns_config,omitempty" yaml:"dns_config"`
+	DnsPolicy          DnsPolicy 		 `json:"dns_policy,omitempty" yaml:"dns_policy"`
 }
 
 // GetVersion returns the resource version.
@@ -106,6 +109,10 @@ type (
 	DNSConfigOptions struct {
 		Name  string  `json:"name,omitempty"`
 		Value *string `json:"value,omitempty" yaml:"value"`
+	}
+
+	DnsPolicy struct {
+		Policy string `json:"policy",omitempty"`
 	}
 
 	// Toleration defines Kubernetes pod tolerations

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -167,6 +167,7 @@ type (
 		ServiceAccountName string            `json:"service_account_name,omitempty"`
 		HostAliases        []HostAlias       `json:"host_aliases,omitempty"`
 		DnsConfig          DnsConfig         `json:"dns_config,omitempty"`
+		DnsPolicy          DnsPolicy         `json:"dns_policy,omitempty"`
 	}
 
 	// HostAlias ...
@@ -193,6 +194,11 @@ type (
 	DNSConfigOptions struct {
 		Name  string  `json:"name,omitempty"`
 		Value *string `json:"value,omitempty"`
+	}
+
+	// DnsPolicy
+	DnsPolicy struct {
+		Policy string `json:"policy,omitempty"`
 	}
 )
 


### PR DESCRIPTION
I have a workload that requires filtering all dns queries and replacing local lookups.

I added a `dns_config` override to my pipeline. It works fine, except that the podspec defaults to `dnsPolicy: ClusterFirst` with no way of overriding it. This leads to a merged resolv.conf including my kubernetes dns server, and some of the lookups in my pipeline subsequently hits that, and my tests fail.

I've added a `dns_policy`, that takes the form

```yaml
dns_policy:
  policy: None
```

resulting in podspec:
```yaml
.spec:
  dnsPolicy: None
```



