### PR TITLE
Stage level requests for kubernetes runner

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -30,19 +30,21 @@ import (
 type compileCommand struct {
 	*internal.Flags
 
-	Source        *os.File
-	Privileged    []string
-	Volumes       map[string]string
-	Environ       map[string]string
-	Labels        map[string]string
-	Secrets       map[string]string
-	Clone         bool
-	Spec          bool
-	Config        string
-	LimitCPU      int64
-	LimitMemory   int64
-	RequestCPU    int64
-	RequestMemory int64
+	Source           *os.File
+	Privileged       []string
+	Volumes          map[string]string
+	Environ          map[string]string
+	Labels           map[string]string
+	Secrets          map[string]string
+	Clone            bool
+	Spec             bool
+	Config           string
+	LimitCPU         int64
+	LimitMemory      int64
+	RequestCPU       int64
+	RequestMemory    int64
+	MinRequestCPU    int64
+	MinRequestMemory int64
 }
 
 func (c *compileCommand) run(*kingpin.ParseContext) error {
@@ -113,10 +115,14 @@ func (c *compileCommand) run(*kingpin.ParseContext) error {
 				CPU:    c.LimitCPU,
 				Memory: c.LimitMemory,
 			},
-			Requests: compiler.ResourceObject{
-				CPU:    c.RequestCPU,
-				Memory: c.RequestMemory,
+			MinRequests: compiler.ResourceObject{
+				CPU:    c.MinRequestCPU,
+				Memory: c.MinRequestMemory,
 			},
+		},
+		StageRequests: compiler.ResourceObject{
+			CPU:    c.RequestCPU,
+			Memory: c.RequestMemory,
 		},
 	}
 
@@ -186,11 +192,17 @@ func registerCompile(app *kingpin.Application) {
 	cmd.Flag("limit-memory", "limit container memory").
 		Int64Var(&c.LimitMemory)
 
-	cmd.Flag("request-cpu", "request container cpu").
+	cmd.Flag("request-cpu", "stage request cpu").
 		Int64Var(&c.RequestCPU)
 
-	cmd.Flag("request-memory", "request container memory").
+	cmd.Flag("request-memory", "stage request memory").
 		Int64Var(&c.RequestMemory)
+
+	cmd.Flag("min-request-cpu", "minimum container request cpu").
+		Int64Var(&c.MinRequestCPU)
+
+	cmd.Flag("min-request-memory", "minimum container request memory").
+		Int64Var(&c.MinRequestMemory)
 
 		// shared pipeline flags
 	c.Flags = internal.ParseFlags(cmd)

--- a/command/daemon/config.go
+++ b/command/daemon/config.go
@@ -68,8 +68,13 @@ type Config struct {
 	Resources struct {
 		LimitCPU      int64     `envconfig:"DRONE_RESOURCE_LIMIT_CPU"`
 		LimitMemory   BytesSize `envconfig:"DRONE_RESOURCE_LIMIT_MEMORY"`
-		RequestCPU    int64     `envconfig:"DRONE_RESOURCE_REQUEST_CPU"`
-		RequestMemory BytesSize `envconfig:"DRONE_RESOURCE_REQUEST_MEMORY"`
+		RequestCPU    int64     `envconfig:"DRONE_RESOURCE_REQUEST_CPU" default:"100"`
+		RequestMemory BytesSize `envconfig:"DRONE_RESOURCE_REQUEST_MEMORY" default:"104857600"` // default 100MB
+		// Defaults for min memory & cpu requests are set to ensure that default limitrange values are not used.
+		// Default for MinRequestMemory is set to 4MB. Anything below 4MB fails with
+		// "Error: Error response from daemon: Minimum memory limit allowed is 4MB" on gke
+		MinRequestMemory BytesSize `envconfig:"DRONE_RESOURCE_MIN_REQUEST_MEMORY" default:"4194304"` // default 4MB
+		MinRequestCPU    int64     `envconfig:"DRONE_RESOURCE_MIN_REQUEST_CPU" default:"1"`
 	}
 
 	Policy struct {

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -163,10 +163,14 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 					CPU:    config.Resources.LimitCPU,
 					Memory: int64(config.Resources.LimitMemory),
 				},
-				Requests: compiler.ResourceObject{
-					CPU:    config.Resources.RequestCPU,
-					Memory: int64(config.Resources.RequestMemory),
+				MinRequests: compiler.ResourceObject{
+					CPU:    config.Resources.MinRequestCPU,
+					Memory: int64(config.Resources.MinRequestMemory),
 				},
+			},
+			StageRequests: compiler.ResourceObject{
+				CPU:    config.Resources.RequestCPU,
+				Memory: int64(config.Resources.RequestMemory),
 			},
 		},
 		Exec: runtime.NewExecer(

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -573,8 +573,12 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 			v.Resources.Requests.CPU = lowerRequestVal.CPU
 			v.Resources.Requests.Memory = lowerRequestVal.Memory
 		}
-		v.Resources.Limits.CPU = max(v.Resources.Requests.CPU, v.Resources.Limits.CPU)
-		v.Resources.Limits.Memory = max(v.Resources.Requests.Memory, v.Resources.Limits.Memory)
+		if v.Resources.Limits.CPU != 0 {
+			v.Resources.Limits.CPU = max(v.Resources.Requests.CPU, v.Resources.Limits.CPU)
+		}
+		if v.Resources.Limits.Memory != 0 {
+			v.Resources.Limits.Memory = max(v.Resources.Requests.Memory, v.Resources.Limits.Memory)
+		}
 	}
 
 	// apply default policy

--- a/engine/compiler/util.go
+++ b/engine/compiler/util.go
@@ -206,11 +206,11 @@ func getStepLowerRequestVal() ResourceObject {
 
 	cpuStr := os.Getenv("DRONE_RESOURCE_MIN_REQUEST_CPU")
 	memoryStr := os.Getenv("DRONE_RESOURCE_MIN_REQUEST_MEMORY")
-	if v, err := strconv.ParseInt(cpuStr, 10, 64); err != nil {
+	if v, err := strconv.ParseInt(cpuStr, 10, 64); err == nil {
 		r.CPU = v
 	}
 
-	if v, err := strconv.ParseInt(memoryStr, 10, 64); err != nil {
+	if v, err := strconv.ParseInt(memoryStr, 10, 64); err == nil {
 		r.Memory = v
 	}
 	return r

--- a/engine/linter/linter.go
+++ b/engine/linter/linter.go
@@ -53,6 +53,9 @@ func New(patterns map[string][]string) *Linter {
 // configuration.
 func (l *Linter) Lint(pm manifest.Resource, repo *drone.Repo) error {
 	pipeline := pm.(*resource.Pipeline)
+	if err := checkStageResources(pipeline); err != nil {
+		return err
+	}
 	if err := checkSteps(pipeline, repo.Trusted); err != nil {
 		return err
 	}
@@ -61,6 +64,16 @@ func (l *Linter) Lint(pm manifest.Resource, repo *drone.Repo) error {
 	}
 	if err := checkNamespace(pipeline.Metadata.Namespace, repo.Slug, l.patterns); err != nil {
 		return err
+	}
+	return nil
+}
+
+func checkStageResources(pipeline *resource.Pipeline) error {
+	if pipeline.Resources.Limits.CPU != 0 {
+		return errors.New("linter: cpu limit cannot be applied at stage level")
+	}
+	if pipeline.Resources.Limits.Memory != 0 {
+		return errors.New("linter: memory limit cannot be applied at stage level")
 	}
 	return nil
 }

--- a/engine/linter/linter_test.go
+++ b/engine/linter/linter_test.go
@@ -188,6 +188,16 @@ func TestLint(t *testing.T) {
 			invalid: true,
 			message: "linter: unknown step dependency detected: test references foo",
 		},
+		{
+			path:    "testdata/invalid_stage_limit_cpu.yml",
+			invalid: true,
+			message: "linter: cpu limit cannot be applied at stage level",
+		},
+		{
+			path:    "testdata/invalid_stage_limit_memory.yml",
+			invalid: true,
+			message: "linter: memory limit cannot be applied at stage level",
+		},
 	}
 	for _, test := range tests {
 		name := path.Base(test.path)

--- a/engine/linter/testdata/invalid_stage_limit_cpu.yml
+++ b/engine/linter/testdata/invalid_stage_limit_cpu.yml
@@ -1,0 +1,17 @@
+---
+kind: pipeline
+type: kubernetes
+name: default
+resources:
+  requests:
+    cpu: 100
+    memory: 100Mi
+  limits:
+    cpu: 100
+
+steps:
+- name: build
+  image: golang
+  commands:
+  - go build
+  - go test

--- a/engine/linter/testdata/invalid_stage_limit_memory.yml
+++ b/engine/linter/testdata/invalid_stage_limit_memory.yml
@@ -1,0 +1,17 @@
+---
+kind: pipeline
+type: kubernetes
+name: default
+resources:
+  requests:
+    cpu: 100
+    memory: 100Mi
+  limits:
+    memory: 100Mi
+
+steps:
+- name: build
+  image: golang
+  commands:
+  - go build
+  - go test

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -36,7 +36,7 @@ type Pipeline struct {
 	Platform    manifest.Platform    `json:"platform,omitempty"`
 	Trigger     manifest.Conditions  `json:"conditions,omitempty"`
 
-	Resources   StageResources    `json:"resources,omitempty"`
+	Resources   Resources         `json:"resources,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	Services    []*Step           `json:"services,omitempty"`
 	Steps       []*Step           `json:"steps,omitempty"`
@@ -190,13 +190,6 @@ type (
 		// resources allowed.
 		Limits ResourceObject `json:"limits,omitempty" yaml:"limits"`
 
-		// Request describes the minimum amount of
-		// compute resources required.
-		Requests ResourceObject `json:"requests,omitempty" yaml:"requests"`
-	}
-
-	// StageResources describes the compute resource requirements for a stage.
-	StageResources struct {
 		// Request describes the minimum amount of
 		// compute resources required.
 		Requests ResourceObject `json:"requests,omitempty" yaml:"requests"`

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -36,6 +36,7 @@ type Pipeline struct {
 	Platform    manifest.Platform    `json:"platform,omitempty"`
 	Trigger     manifest.Conditions  `json:"conditions,omitempty"`
 
+	Resources   StageResources    `json:"resources,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	Services    []*Step           `json:"services,omitempty"`
 	Steps       []*Step           `json:"steps,omitempty"`
@@ -189,6 +190,13 @@ type (
 		// resources allowed.
 		Limits ResourceObject `json:"limits,omitempty" yaml:"limits"`
 
+		// Request describes the minimum amount of
+		// compute resources required.
+		Requests ResourceObject `json:"requests,omitempty" yaml:"requests"`
+	}
+
+	// StageResources describes the compute resource requirements for a stage.
+	StageResources struct {
 		// Request describes the minimum amount of
 		// compute resources required.
 		Requests ResourceObject `json:"requests,omitempty" yaml:"requests"`

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/99designs/basicauth-go v0.0.0-20160802081356-2a93ba0f464d h1:j6oB/WPCigdOkxtuPl1VSIiLpy7Mdsu6phQffbF19Ng=
 github.com/99designs/basicauth-go v0.0.0-20160802081356-2a93ba0f464d/go.mod h1:3cARGAK9CfW3HoxCy1a0G4TKrdiKke8ftOMEOHyySYs=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"github.com/drone-runners/drone-runner-kube/command"
 	_ "github.com/joho/godotenv/autoload"
+        _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func main() {


### PR DESCRIPTION
Drone currently allows setting step level memory request & limits. There is a disadvantage with the approach that k8 will reserve memory and cpu equal to sum of all the step requests which is used for selecting a node to schedule the pod. But only one step runs at a time. Hence, resources are wasted if step requests are not set properly.

This patch provides an option to set the stage level memory & cpu requests. It will ensure that k8 reserves only this much amount of resources to schedule the pod.