### PR TITLE
Terminate pod on build cancellation

### DIFF
--- a/engine/cancellable_copy.go
+++ b/engine/cancellable_copy.go
@@ -1,0 +1,26 @@
+package engine
+
+import (
+	"context"
+	"io"
+
+	"github.com/drone/runner-go/livelog"
+)
+
+// cancellableCopy method provides a way to copy from source to destination
+// that honors context. If context.Cancel is called, copy method will return immediately.
+func cancellableCopy(ctx context.Context, dst io.Writer, src io.ReadCloser) error {
+	ch := make(chan error)
+	go func() {
+		err := livelog.Copy(dst, src)
+		ch <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		src.Close()
+		return ctx.Err()
+	case err := <-ch:
+		return err
+	}
+}

--- a/engine/cancellable_copy.go
+++ b/engine/cancellable_copy.go
@@ -7,8 +7,8 @@ import (
 	"github.com/drone/runner-go/livelog"
 )
 
-// cancellableCopy method provides a way to copy from source to destination
-// that honors context. If context.Cancel is called, copy method will return immediately.
+// cancellableCopy method copies from source to destination honoring the context.
+// If context.Cancel is called, it will return immediately with context cancelled error.
 func cancellableCopy(ctx context.Context, dst io.Writer, src io.ReadCloser) error {
 	ch := make(chan error)
 	go func() {

--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/drone-runners/drone-runner-kube/internal/docker/image"
-	"github.com/drone/runner-go/livelog"
 	"github.com/drone/runner-go/pipeline/runtime"
 	"github.com/hashicorp/go-multierror"
 	v1 "k8s.io/api/core/v1"
@@ -306,7 +305,7 @@ func (k *Kubernetes) tail(ctx context.Context, spec *Spec, step *Step, output io
 	}
 	defer readCloser.Close()
 
-	return livelog.Copy(output, readCloser)
+	return cancellableCopy(ctx, output, readCloser)
 }
 
 func (k *Kubernetes) start(spec *Spec, step *Step) error {


### PR DESCRIPTION
On cancelling a build from UI, pod are not getting terminated. The issue was context was not honoured in tail method. Tail blocks on copying the logs to a destination inside the Run method. Hence, the pod was not getting terminated.

Fix: This fix makes the log copy cancellable by honouring the context.