### PR TITLE
Add ephemeral-storage to resource requests/limits

### DIFF
--- a/command/daemon/config.go
+++ b/command/daemon/config.go
@@ -66,10 +66,12 @@ type Config struct {
 	}
 
 	Resources struct {
-		LimitCPU      int64     `envconfig:"DRONE_RESOURCE_LIMIT_CPU"`
-		LimitMemory   BytesSize `envconfig:"DRONE_RESOURCE_LIMIT_MEMORY"`
-		RequestCPU    int64     `envconfig:"DRONE_RESOURCE_REQUEST_CPU" default:"100"`
-		RequestMemory BytesSize `envconfig:"DRONE_RESOURCE_REQUEST_MEMORY" default:"104857600"` // default 100MB
+		LimitCPU       int64     `envconfig:"DRONE_RESOURCE_LIMIT_CPU"`
+		LimitMemory    BytesSize `envconfig:"DRONE_RESOURCE_LIMIT_MEMORY"`
+		LimitStorage   BytesSize `envconfig:"DRONE_RESOURCE_LIMIT_STORAGE"`
+		RequestCPU     int64     `envconfig:"DRONE_RESOURCE_REQUEST_CPU" default:"100"`
+		RequestMemory  BytesSize `envconfig:"DRONE_RESOURCE_REQUEST_MEMORY" default:"104857600"` // default 100MB
+		RequestStorage BytesSize `envconfig:"DRONE_RESOURCE_REQUEST_STORAGE"`
 		// Defaults for min memory & cpu requests are set to ensure that default limitrange values are not used.
 		// Default for MinRequestMemory is set to 4MB. Anything below 4MB fails with
 		// "Error: Error response from daemon: Minimum memory limit allowed is 4MB" on gke

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -160,8 +160,9 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 			),
 			Resources: compiler.Resources{
 				Limits: compiler.ResourceObject{
-					CPU:    config.Resources.LimitCPU,
-					Memory: int64(config.Resources.LimitMemory),
+					CPU:              config.Resources.LimitCPU,
+					Memory:           int64(config.Resources.LimitMemory),
+					EphemeralStorage: int64(config.Resources.LimitStorage),
 				},
 				MinRequests: compiler.ResourceObject{
 					CPU:    config.Resources.MinRequestCPU,
@@ -169,8 +170,9 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 				},
 			},
 			StageRequests: compiler.ResourceObject{
-				CPU:    config.Resources.RequestCPU,
-				Memory: int64(config.Resources.RequestMemory),
+				CPU:              config.Resources.RequestCPU,
+				Memory:           int64(config.Resources.RequestMemory),
+				EphemeralStorage: int64(config.Resources.RequestStorage),
 			},
 			Tmate: compiler.Tmate{
 				Image:   config.Tmate.Image,

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -55,8 +55,9 @@ type (
 
 	// ResourceObject describes compute resource requirements.
 	ResourceObject struct {
-		CPU    int64
-		Memory int64
+		CPU              int64
+		Memory           int64
+		EphemeralStorage int64
 	}
 
 	// Tmate defines tmate settings.
@@ -597,6 +598,9 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 		if v.Resources.Limits.Memory == 0 {
 			v.Resources.Limits.Memory = c.Resources.Limits.Memory
 		}
+		if v.Resources.Limits.EphemeralStorage == 0 {
+			v.Resources.Limits.EphemeralStorage = c.Resources.Limits.EphemeralStorage
+		}
 	}
 
 	numSteps := int64(len(spec.Steps))
@@ -617,18 +621,26 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 				lowerRequestVal.CPU)
 			mem := max(upperRequestVal.Memory-(numSteps-1)*lowerRequestVal.Memory,
 				lowerRequestVal.Memory)
+			store := max(upperRequestVal.EphemeralStorage-(numSteps-1)*lowerRequestVal.EphemeralStorage,
+				lowerRequestVal.EphemeralStorage)
 
 			v.Resources.Requests.CPU = cpu
 			v.Resources.Requests.Memory = mem
+			v.Resources.Requests.EphemeralStorage = store
 		} else {
 			v.Resources.Requests.CPU = lowerRequestVal.CPU
 			v.Resources.Requests.Memory = lowerRequestVal.Memory
+			v.Resources.Requests.EphemeralStorage = lowerRequestVal.EphemeralStorage
 		}
 		if v.Resources.Limits.CPU != 0 {
 			v.Resources.Limits.CPU = max(v.Resources.Requests.CPU, v.Resources.Limits.CPU)
 		}
 		if v.Resources.Limits.Memory != 0 {
 			v.Resources.Limits.Memory = max(v.Resources.Requests.Memory, v.Resources.Limits.Memory)
+		}
+		if v.Resources.Limits.EphemeralStorage != 0 {
+			v.Resources.Limits.EphemeralStorage = max(v.Resources.Requests.EphemeralStorage,
+				v.Resources.Limits.EphemeralStorage)
 		}
 	}
 

--- a/engine/compiler/util.go
+++ b/engine/compiler/util.go
@@ -98,8 +98,9 @@ func convertSecretEnv(src map[string]*manifest.Variable) []*engine.SecretVar {
 func convertResources(src resource.Resources) engine.Resources {
 	return engine.Resources{
 		Limits: engine.ResourceObject{
-			CPU:    src.Limits.CPU,
-			Memory: int64(src.Limits.Memory),
+			CPU:              src.Limits.CPU,
+			Memory:           int64(src.Limits.Memory),
+			EphemeralStorage: int64(src.Limits.EphemeralStorage),
 		},
 	}
 }
@@ -192,14 +193,18 @@ func isRestrictedVariable(env map[string]*manifest.Variable) bool {
 func getStepUpperRequestVal(stageResources resource.Resources,
 	defaultRequests ResourceObject) ResourceObject {
 	r := ResourceObject{
-		CPU:    stageResources.Requests.CPU,
-		Memory: int64(stageResources.Requests.Memory),
+		CPU:              stageResources.Requests.CPU,
+		Memory:           int64(stageResources.Requests.Memory),
+		EphemeralStorage: int64(stageResources.Limits.EphemeralStorage),
 	}
 	if r.CPU == 0 {
 		r.CPU = defaultRequests.CPU
 	}
 	if r.Memory == 0 {
 		r.Memory = defaultRequests.Memory
+	}
+	if r.EphemeralStorage == 0 {
+		r.EphemeralStorage = defaultRequests.EphemeralStorage
 	}
 	return r
 }

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -198,7 +198,8 @@ type (
 	// ResourceObject describes compute resource
 	// requirements.
 	ResourceObject struct {
-		CPU    int64              `json:"cpu" yaml:"cpu"`
-		Memory manifest.BytesSize `json:"memory"`
+		CPU              int64              `json:"cpu" yaml:"cpu"`
+		Memory           manifest.BytesSize `json:"memory"`
+		EphemeralStorage manifest.BytesSize `json:"ephemeral-storage"`
 	}
 )

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -152,8 +152,9 @@ type (
 
 	// ResourceObject describes compute resource requirements.
 	ResourceObject struct {
-		CPU    int64 `json:"cpu"`
-		Memory int64 `json:"memory"`
+		CPU              int64 `json:"cpu"`
+		Memory           int64 `json:"memory"`
+		EphemeralStorage int64 `json:"ephemeral-storage"`
 	}
 
 	// PodSpec ...


### PR DESCRIPTION
* Allow `kubernetes` pipelines to define resource requests/limits that include `ephemeral-storage` (same units as memory). This can be handy for pipelines that use a lot of scratch space or emptyDir
* Can be used in a pipeline or by setting env vars for the runner
  * `DRONE_RESOURCE_REQUEST_STORAGE`
  * `DRONE_RESOURCE_LIMIT_STORAGE`

```yaml
steps:
  - name: build
    image: golang
    commands:
      - go test
    resources:
      requests:
        memory: 500MiB
        ephemeral-storage: 2Gi
```

Docs: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage

