### PR TITLE
update: PodWatcher does not require container list in advance

### DIFF
--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -132,10 +132,6 @@ func (k *Kubernetes) Setup(ctx context.Context, specv runtime.Spec) error {
 	// Start a watcher that watches all k8s event related to the pod just created.
 	// The watcher will finish when the pod is deleted.
 	k.watcher = &podwatcher.PodWatcher{}
-	for idx, step := range spec.Steps {
-		// register all steps as containers inside the pod
-		k.watcher.AddContainer(idx, step.ID, step.Image, step.Placeholder)
-	}
 	k.watcher.Start(ctx, &podwatcher.KubernetesWatcher{
 		PodNamespace: pod.Namespace,
 		PodName:      pod.Name,
@@ -191,6 +187,9 @@ func (k *Kubernetes) Destroy(ctx context.Context, specv runtime.Spec) error {
 func (k *Kubernetes) Run(ctx context.Context, specv runtime.Spec, stepv runtime.Step, output io.Writer) (*runtime.State, error) {
 	spec := specv.(*Spec)
 	step := stepv.(*Step)
+
+	// start tracking the container with this name
+	k.watcher.AddContainer(step.ID, step.Placeholder)
 
 	err := k.start(spec, step)
 	if err != nil {

--- a/engine/podwatcher/container.go
+++ b/engine/podwatcher/container.go
@@ -16,13 +16,13 @@ type ContainerWatcher interface {
 	// Watch waits for the container updates and puts the new status to the channel.
 	// The function should close the containers channel when it finishes.
 	// It should finish either when the context is done or when no more events are expected.
-	Watch(ctx context.Context, containers chan<- []containerCurrentStatus) error
+	Watch(ctx context.Context, containers chan<- []containerInfo) error
 
 	// PeriodicCheck should periodically put the current state of the containers to the channel.
 	// The function should close the containers channel when it finishes.
 	// It should finish either when the context is done or when the stop channel is closed.
 	// To disable the feature, the function should be a no op, and the containers channel should remain open.
-	PeriodicCheck(ctx context.Context, containers chan<- []containerCurrentStatus, stop <-chan struct{}) error
+	PeriodicCheck(ctx context.Context, containers chan<- []containerInfo, stop <-chan struct{}) error
 }
 
 // client represents a process that waits for a container state change.
@@ -34,42 +34,26 @@ type client struct {
 	resolveCh      chan error
 }
 
-type containerStatus struct {
-	currentState     containerState
-	currentStateInfo string
-	currentImage     string
-	exitCode         int32
-}
-
-type containerCurrentStatus struct {
-	id string
-	containerStatus
-}
-
 // containerInfo is used by the PodWatcher to track state of each container inside of a pod.
 type containerInfo struct {
-	// definition fields
-	idx         int
 	id          string
-	image       string
+	state       containerState
+	stateInfo   string
 	placeholder string
-	// current status
-	containerStatus
+	image       string
+	exitCode    int32
 }
 
 type containerState int
 
 const (
-	statePending containerState = iota
-	stateWaiting
+	stateWaiting containerState = iota
 	stateRunning
 	stateTerminated
 )
 
 func (s containerState) String() string {
 	switch s {
-	case statePending:
-		return "PENDING"
 	case stateWaiting:
 		return "WAITING"
 	case stateRunning:


### PR DESCRIPTION
The old behavior required that all containers for all steps are added to PodWatcher in advance. However, some users reported "unknown container" error with that approach. The error happens is when a step waits for a state change of a container that was not previously registered.

The new behavior requires that a container is marked for watching immediately before its step is started. Only after that PodWatcher will monitor containers state changes. This should eliminate "unknown container" errors.