### PR TITLE
Align step resources name with both doc and underlying system.

### DIFF
--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -131,7 +131,7 @@ type (
 		Name        string                         `json:"name,omitempty"`
 		Privileged  bool                           `json:"privileged,omitempty"`
 		Pull        string                         `json:"pull,omitempty"`
-		Resources   Resources                      `json:"resource,omitempty"`
+		Resources   Resources                      `json:"resources,omitempty"`
 		Settings    map[string]*manifest.Parameter `json:"settings,omitempty"`
 		Shell       string                         `json:"shell,omitempty"`
 		User        *int64                         `json:"user,omitempty"`


### PR DESCRIPTION
The Drone Kubernetes Runner documentation as well as the underlying
kubernetes manifest use the term "resources" while the implementation of
the steps code uses "resource". This causes confusion and either
requires the end user to use environment variable minimums, policies or
look at the underlying implementation to figure out why their pipelines
are only using the defaults.

