### PR TITLE
feat: Add support for config_map volumes

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -593,6 +593,15 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 				ClaimName: v.Claim.ClaimName,
 				ReadOnly:  v.Claim.ReadOnly,
 			}
+		} else if v.ConfigMap != nil {
+			src.ConfigMap = &engine.VolumeConfigMap{
+				ID:            id,
+				Name:          v.Name,
+				ConfigMapName: v.ConfigMap.ConfigMapName,
+				Optional:      v.ConfigMap.Optional,
+				DefaultMode:   v.ConfigMap.DefaultMode,
+			}
+
 		} else {
 			continue
 		}

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -131,6 +131,22 @@ func toVolumes(spec *Spec) []v1.Volume {
 			volumes = append(volumes, volume)
 		}
 
+		if v.ConfigMap != nil {
+			volume := v1.Volume{
+				Name: v.ConfigMap.ID,
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: v.ConfigMap.ConfigMapName,
+						},
+						Optional:    &v.ConfigMap.Optional,
+						DefaultMode: &v.ConfigMap.DefaultMode,
+					},
+				},
+			}
+			volumes = append(volumes, volume)
+		}
+
 		if v.DownwardAPI != nil {
 			var items []v1.DownwardAPIVolumeFile
 
@@ -356,6 +372,10 @@ func lookupVolumeID(spec *Spec, name string) (string, bool) {
 
 		if v.Claim != nil && v.Claim.Name == name {
 			return v.Claim.ID, true
+		}
+
+		if v.ConfigMap != nil && v.ConfigMap.Name == name {
+			return v.ConfigMap.ID, true
 		}
 
 		if v.DownwardAPI != nil && v.DownwardAPI.Name == name {

--- a/engine/linter/linter.go
+++ b/engine/linter/linter.go
@@ -147,6 +147,12 @@ func checkVolumes(pipeline *resource.Pipeline, trusted bool) error {
 				return err
 			}
 		}
+		if volume.ConfigMap != nil {
+			err := checkConfigMapVolume(volume.ConfigMap, trusted)
+			if err != nil {
+				return err
+			}
+		}
 		switch volume.Name {
 		case "":
 			return fmt.Errorf("linter: missing volume name")
@@ -167,6 +173,13 @@ func checkHostPathVolume(volume *resource.VolumeHostPath, trusted bool) error {
 func checkClaimVolume(volume *resource.VolumeClaim, trusted bool) error {
 	if trusted == false {
 		return errors.New("linter: untrusted repositories cannot mount PVC")
+	}
+	return nil
+}
+
+func checkConfigMapVolume(volume *resource.VolumeConfigMap, trusted bool) error {
+	if trusted == false {
+		return errors.New("linter: untrusted repositories cannot mount configMap volumes")
 	}
 	return nil
 }

--- a/engine/linter/linter_test.go
+++ b/engine/linter/linter_test.go
@@ -64,6 +64,19 @@ func TestLint(t *testing.T) {
 			trusted: true,
 			invalid: false,
 		},
+		// user should not be able to mount configmap
+		// volumes unless the repository is trusted.
+		{
+			path:    "testdata/volume_configmap.yml",
+			trusted: false,
+			invalid: true,
+			message: "linter: untrusted repositories cannot mount configMap volumes",
+		},
+		{
+			path:    "testdata/volume_configmap.yml",
+			trusted: true,
+			invalid: false,
+		},
 		// user should not be able to mount persistent volume claims
 		// volumes unless the repository is trusted.
 		{

--- a/engine/linter/testdata/volume_configmap.yml
+++ b/engine/linter/testdata/volume_configmap.yml
@@ -1,0 +1,35 @@
+kind: pipeline
+type: kubernetes
+name: default
+
+clone:
+  disable: true
+
+steps:
+- name: write
+  pull: if-not-exists
+  image: alpine
+  volumes:
+  - name: shared
+    path: /shared
+  commands:
+  - pwd
+  - echo "hello" > /shared/greetings.txt
+
+- name: read
+  pull: if-not-exists
+  image: alpine
+  volumes:
+  - name: shared
+    path: /shared
+  commands:
+  - pwd
+  - ls /shared
+  - cat /shared/greetings.txt
+
+volumes:
+- name: shared
+  config_map:
+    name: received-data-claim
+    default_mode: 420
+    optional: false

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -143,10 +143,11 @@ type (
 
 	// Volume that can be mounted by containers.
 	Volume struct {
-		Name     string          `json:"name,omitempty"`
-		EmptyDir *VolumeEmptyDir `json:"temp,omitempty" yaml:"temp"`
-		HostPath *VolumeHostPath `json:"host,omitempty" yaml:"host"`
-		Claim    *VolumeClaim    `json:"claim,omitempty" yaml:"claim"`
+		Name      string           `json:"name,omitempty"`
+		EmptyDir  *VolumeEmptyDir  `json:"temp,omitempty" yaml:"temp"`
+		HostPath  *VolumeHostPath  `json:"host,omitempty" yaml:"host"`
+		Claim     *VolumeClaim     `json:"claim,omitempty" yaml:"claim"`
+		ConfigMap *VolumeConfigMap `json:"config_map,omitempty" yaml:"config_map"`
 	}
 
 	// VolumeMount describes a mounting of a Volume
@@ -176,6 +177,14 @@ type (
 	VolumeClaim struct {
 		ClaimName string `json:"name,omitempty" yaml:"name"`
 		ReadOnly  bool   `json:"read_only,omitempty" yaml:"read_only"`
+	}
+
+	// VolumeConfigMap mounts a Kubernetes configmap into the container.
+	// persistentVolumeClaim.
+	VolumeConfigMap struct {
+		ConfigMapName string `json:"name,omitempty" yaml:"name"`
+		DefaultMode   int32  `json:"default_mode,omitempty" yaml:"default_mode"`
+		Optional      bool   `json:"optional,omitempty" yaml:"optional"`
 	}
 
 	// Workspace represents the pipeline workspace configuration.

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -102,6 +102,7 @@ type (
 		HostPath    *VolumeHostPath    `json:"host,omitempty"`
 		DownwardAPI *VolumeDownwardAPI `json:"downward_api,omitempty"`
 		Claim       *VolumeClaim       `json:"claim,omitempty"`
+		ConfigMap   *VolumeConfigMap   `json:"config_map,omitempty"`
 	}
 
 	// VolumeMount describes a mounting of a Volume
@@ -148,6 +149,15 @@ type (
 		Name      string `json:"name,omitempty"`
 		ClaimName string `json:"claim_name,omitempty"`
 		ReadOnly  bool   `json:"read_only,omitempty"`
+	}
+
+	// VolumeConfigMap ...
+	VolumeConfigMap struct {
+		ID            string `json:"id,omitempty"`
+		Name          string `json:"name,omitempty"`
+		ConfigMapName string `json:"config_map_name,omitempty"`
+		DefaultMode   int32  `json:"default_mode,omitempty"`
+		Optional      bool   `json:"optional,omitempty"`
 	}
 
 	// Resources describes the compute resource requirements.


### PR DESCRIPTION
## Support `config_map` volumes

Add support for kubernetes config maps as volumes.

This is a great help in letting our runners include less copy-pasted code or data.

```
kind: pipeline
type: kubernetes
name: default

clone:
  disable: true

steps:
- name: write
  pull: if-not-exists
  image: alpine
  volumes:
  - name: shared
    path: /shared
  commands:
  - pwd
  - echo "hello" > /shared/greetings.txt

- name: read
  pull: if-not-exists
  image: alpine
  volumes:
  - name: shared
    path: /shared
  commands:
  - pwd
  - ls /shared
  - cat /shared/greetings.txt

volumes:
- name: shared
  config_map:
    name: received-data-claim
    default_mode: 420
    optional: false
```