### PR TITLE
feat: Add support for secret volumes

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -601,7 +601,14 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 				Optional:      v.ConfigMap.Optional,
 				DefaultMode:   v.ConfigMap.DefaultMode,
 			}
-
+		} else if v.Secret != nil {
+			src.Secret = &engine.VolumeSecret{
+				ID:          id,
+				Name:        v.Name,
+				SecretName:  v.Secret.SecretName,
+				Optional:    v.Secret.Optional,
+				DefaultMode: v.Secret.DefaultMode,
+			}
 		} else {
 			continue
 		}

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -147,6 +147,20 @@ func toVolumes(spec *Spec) []v1.Volume {
 			volumes = append(volumes, volume)
 		}
 
+		if v.Secret != nil {
+			volume := v1.Volume{
+				Name: v.Secret.ID,
+				VolumeSource: v1.VolumeSource{
+					Secret: &v1.SecretVolumeSource{
+						SecretName:  v.Secret.SecretName,
+						Optional:    &v.Secret.Optional,
+						DefaultMode: &v.Secret.DefaultMode,
+					},
+				},
+			}
+			volumes = append(volumes, volume)
+		}
+
 		if v.DownwardAPI != nil {
 			var items []v1.DownwardAPIVolumeFile
 
@@ -376,6 +390,10 @@ func lookupVolumeID(spec *Spec, name string) (string, bool) {
 
 		if v.ConfigMap != nil && v.ConfigMap.Name == name {
 			return v.ConfigMap.ID, true
+		}
+
+		if v.Secret != nil && v.Secret.Name == name {
+			return v.Secret.ID, true
 		}
 
 		if v.DownwardAPI != nil && v.DownwardAPI.Name == name {

--- a/engine/linter/linter.go
+++ b/engine/linter/linter.go
@@ -153,6 +153,12 @@ func checkVolumes(pipeline *resource.Pipeline, trusted bool) error {
 				return err
 			}
 		}
+		if volume.Secret != nil {
+			err := checkSecretVolume(volume.Secret, trusted)
+			if err != nil {
+				return err
+			}
+		}
 		switch volume.Name {
 		case "":
 			return fmt.Errorf("linter: missing volume name")
@@ -180,6 +186,13 @@ func checkClaimVolume(volume *resource.VolumeClaim, trusted bool) error {
 func checkConfigMapVolume(volume *resource.VolumeConfigMap, trusted bool) error {
 	if trusted == false {
 		return errors.New("linter: untrusted repositories cannot mount configMap volumes")
+	}
+	return nil
+}
+
+func checkSecretVolume(volume *resource.VolumeSecret, trusted bool) error {
+	if trusted == false {
+		return errors.New("linter: untrusted repositories cannot mount secret volumes")
 	}
 	return nil
 }

--- a/engine/linter/linter_test.go
+++ b/engine/linter/linter_test.go
@@ -77,6 +77,19 @@ func TestLint(t *testing.T) {
 			trusted: true,
 			invalid: false,
 		},
+		// user should not be able to mount secret
+		// volumes unless the repository is trusted.
+		{
+			path:    "testdata/volume_secret.yml",
+			trusted: false,
+			invalid: true,
+			message: "linter: untrusted repositories cannot mount secret volumes",
+		},
+		{
+			path:    "testdata/volume_secret.yml",
+			trusted: true,
+			invalid: false,
+		},
 		// user should not be able to mount persistent volume claims
 		// volumes unless the repository is trusted.
 		{

--- a/engine/linter/testdata/volume_secret.yml
+++ b/engine/linter/testdata/volume_secret.yml
@@ -1,0 +1,35 @@
+kind: pipeline
+type: kubernetes
+name: default
+
+clone:
+  disable: true
+
+steps:
+- name: write
+  pull: if-not-exists
+  image: alpine
+  volumes:
+  - name: shared
+    path: /shared
+  commands:
+  - pwd
+  - echo "hello" > /shared/greetings.txt
+
+- name: read
+  pull: if-not-exists
+  image: alpine
+  volumes:
+  - name: shared
+    path: /shared
+  commands:
+  - pwd
+  - ls /shared
+  - cat /shared/greetings.txt
+
+volumes:
+- name: shared
+  secret:
+    name: received-data-claim
+    default_mode: 420
+    optional: false

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -148,6 +148,7 @@ type (
 		HostPath  *VolumeHostPath  `json:"host,omitempty" yaml:"host"`
 		Claim     *VolumeClaim     `json:"claim,omitempty" yaml:"claim"`
 		ConfigMap *VolumeConfigMap `json:"config_map,omitempty" yaml:"config_map"`
+		Secret    *VolumeSecret    `json:"secret,omitempty" yaml:"secret"`
 	}
 
 	// VolumeMount describes a mounting of a Volume
@@ -180,11 +181,17 @@ type (
 	}
 
 	// VolumeConfigMap mounts a Kubernetes configmap into the container.
-	// persistentVolumeClaim.
 	VolumeConfigMap struct {
 		ConfigMapName string `json:"name,omitempty" yaml:"name"`
 		DefaultMode   int32  `json:"default_mode,omitempty" yaml:"default_mode"`
 		Optional      bool   `json:"optional,omitempty" yaml:"optional"`
+	}
+
+	// VolumeSecret mounts a Kubernetes configmap into the container.
+	VolumeSecret struct {
+		SecretName  string `json:"name,omitempty" yaml:"name"`
+		DefaultMode int32  `json:"default_mode,omitempty" yaml:"default_mode"`
+		Optional    bool   `json:"optional,omitempty" yaml:"optional"`
 	}
 
 	// Workspace represents the pipeline workspace configuration.

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -103,6 +103,7 @@ type (
 		DownwardAPI *VolumeDownwardAPI `json:"downward_api,omitempty"`
 		Claim       *VolumeClaim       `json:"claim,omitempty"`
 		ConfigMap   *VolumeConfigMap   `json:"config_map,omitempty"`
+		Secret      *VolumeSecret      `json:"secret,omitempty"`
 	}
 
 	// VolumeMount describes a mounting of a Volume
@@ -158,6 +159,15 @@ type (
 		ConfigMapName string `json:"config_map_name,omitempty"`
 		DefaultMode   int32  `json:"default_mode,omitempty"`
 		Optional      bool   `json:"optional,omitempty"`
+	}
+
+	// VolumeSecret ...
+	VolumeSecret struct {
+		ID          string `json:"id,omitempty"`
+		Name        string `json:"name,omitempty"`
+		SecretName  string `json:"secret_name,omitempty"`
+		DefaultMode int32  `json:"default_mode,omitempty"`
+		Optional    bool   `json:"optional,omitempty"`
 	}
 
 	// Resources describes the compute resource requirements.


### PR DESCRIPTION
## Support `secret` volumes

Add support for kubernetes secrets as volumes.

This is a great help in letting our runners include less copy-pasted code or data.

```
kind: pipeline
type: kubernetes
name: default

clone:
  disable: true

steps:
- name: write
  pull: if-not-exists
  image: alpine
  volumes:
  - name: shared
    path: /shared
  commands:
  - pwd
  - echo "hello" > /shared/greetings.txt

- name: read
  pull: if-not-exists
  image: alpine
  volumes:
  - name: shared
    path: /shared
  commands:
  - pwd
  - ls /shared
  - cat /shared/greetings.txt

volumes:
- name: shared
  secret:
    name: received-data-claim
    default_mode: 420
    optional: false
```