### PR TITLE
Allow merging of Tolerations and NodeSelector in Policy config

### DIFF
--- a/engine/policy/policy.go
+++ b/engine/policy/policy.go
@@ -99,14 +99,15 @@ func (p *Policy) Apply(spec *engine.Spec) {
 	}
 
 	// apply the default nodeselector.
-	if ns := p.NodeSelector; ns != nil {
-		if p.MergeNodeSelector {
-			for k, v := range p.NodeSelector {
+	switch ns := p.NodeSelector; ns != nil {
+	case p.MergeNodeSelector:
+		for k, v := range ns {
+			if spec.PodSpec.NodeSelector[k] == "" {
 				spec.PodSpec.NodeSelector[k] = v
 			}
-		} else {
-			spec.PodSpec.NodeSelector = ns
 		}
+	default:
+		spec.PodSpec.NodeSelector = ns
 	}
 
 	// apply the default service account.

--- a/engine/policy/policy_test.go
+++ b/engine/policy/policy_test.go
@@ -3,3 +3,98 @@
 // that can be found in the LICENSE file.
 
 package policy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/drone-runners/drone-runner-kube/engine"
+)
+
+func TestTolerations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		p    *Policy
+		want []engine.Toleration
+	}{
+		{
+			desc: "test override tolerations",
+			p: &Policy{
+				Tolerations: []Toleration{{Key: "policy"}},
+			},
+			want: []engine.Toleration{
+				{Key: "policy"},
+			},
+		},
+		{
+			desc: "test append tolerations",
+			p: &Policy{
+				AppendTolerations: true,
+				Tolerations:       []Toleration{{Key: "policy"}},
+			},
+			want: []engine.Toleration{
+				{Key: "spec"},
+				{Key: "policy"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		spec := &engine.Spec{
+			PodSpec: engine.PodSpec{
+				Tolerations: []engine.Toleration{{Key: "spec"}},
+			},
+		}
+
+		test.p.Apply(spec)
+
+		if !reflect.DeepEqual(test.want, spec.PodSpec.Tolerations) {
+			t.Errorf("tolerations are incorrect\ndesc: %s\nexpected: %#v\ngot: %#v", test.desc, test.want, spec.PodSpec.Tolerations)
+		}
+	}
+}
+
+func TestNodeSelectors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		p    *Policy
+		want map[string]string
+	}{
+		{
+			desc: "test override node_selector",
+			p: &Policy{
+				NodeSelector: map[string]string{"policy": ""},
+			},
+			want: map[string]string{"policy": ""},
+		},
+		{
+			desc: "test merge node_selector",
+			p: &Policy{
+				MergeNodeSelector: true,
+				NodeSelector:      map[string]string{"policy": ""},
+			},
+			want: map[string]string{
+				"policy": "",
+				"spec":   "",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		spec := &engine.Spec{
+			PodSpec: engine.PodSpec{
+				NodeSelector: map[string]string{"spec": ""},
+			},
+		}
+
+		test.p.Apply(spec)
+
+		if !reflect.DeepEqual(test.want, spec.PodSpec.NodeSelector) {
+			t.Errorf("node_selector is incorrect\ndesc: %s\nexpected: %#v\ngot: %#v", test.desc, test.want, spec.PodSpec.NodeSelector)
+		}
+	}
+}

--- a/engine/policy/policy_test.go
+++ b/engine/policy/policy_test.go
@@ -22,21 +22,21 @@ func TestTolerations(t *testing.T) {
 		{
 			desc: "test override tolerations",
 			p: &Policy{
-				Tolerations: []Toleration{{Key: "drone-nodes"}},
+				Tolerations: []Toleration{{Key: "drone"}},
 			},
 			want: []engine.Toleration{
-				{Key: "drone-nodes"},
+				{Key: "drone"},
 			},
 		},
 		{
 			desc: "test append tolerations",
 			p: &Policy{
 				AppendTolerations: true,
-				Tolerations:       []Toleration{{Key: "drone-nodes"}},
+				Tolerations:       []Toleration{{Key: "drone"}},
 			},
 			want: []engine.Toleration{
 				{Key: "memory-optimized"},
-				{Key: "drone-nodes"},
+				{Key: "drone"},
 			},
 		},
 	}
@@ -67,19 +67,19 @@ func TestNodeSelectors(t *testing.T) {
 		{
 			desc: "test override node_selector",
 			p: &Policy{
-				NodeSelector: map[string]string{"drone-nodes": ""},
+				NodeSelector: map[string]string{"instancegroup": "drone"},
 			},
-			want: map[string]string{"drone-nodes": ""},
+			want: map[string]string{"instancegroup": "drone"},
 		},
 		{
 			desc: "test merge node_selector",
 			p: &Policy{
 				MergeNodeSelector: true,
-				NodeSelector:      map[string]string{"drone-nodes": ""},
+				NodeSelector:      map[string]string{"instancegroup": "drone"},
 			},
 			want: map[string]string{
-				"drone-nodes":      "",
-				"memory-optimized": "",
+				"instancegroup": "drone",
+				"instanceclass": "memory-optimized",
 			},
 		},
 	}
@@ -87,7 +87,7 @@ func TestNodeSelectors(t *testing.T) {
 	for _, test := range tests {
 		spec := &engine.Spec{
 			PodSpec: engine.PodSpec{
-				NodeSelector: map[string]string{"memory-optimized": ""},
+				NodeSelector: map[string]string{"instanceclass": "memory-optimized"},
 			},
 		}
 

--- a/engine/policy/policy_test.go
+++ b/engine/policy/policy_test.go
@@ -22,21 +22,21 @@ func TestTolerations(t *testing.T) {
 		{
 			desc: "test override tolerations",
 			p: &Policy{
-				Tolerations: []Toleration{{Key: "policy"}},
+				Tolerations: []Toleration{{Key: "drone-nodes"}},
 			},
 			want: []engine.Toleration{
-				{Key: "policy"},
+				{Key: "drone-nodes"},
 			},
 		},
 		{
 			desc: "test append tolerations",
 			p: &Policy{
 				AppendTolerations: true,
-				Tolerations:       []Toleration{{Key: "policy"}},
+				Tolerations:       []Toleration{{Key: "drone-nodes"}},
 			},
 			want: []engine.Toleration{
-				{Key: "spec"},
-				{Key: "policy"},
+				{Key: "memory-optimized"},
+				{Key: "drone-nodes"},
 			},
 		},
 	}
@@ -44,7 +44,7 @@ func TestTolerations(t *testing.T) {
 	for _, test := range tests {
 		spec := &engine.Spec{
 			PodSpec: engine.PodSpec{
-				Tolerations: []engine.Toleration{{Key: "spec"}},
+				Tolerations: []engine.Toleration{{Key: "memory-optimized"}},
 			},
 		}
 
@@ -67,19 +67,19 @@ func TestNodeSelectors(t *testing.T) {
 		{
 			desc: "test override node_selector",
 			p: &Policy{
-				NodeSelector: map[string]string{"policy": ""},
+				NodeSelector: map[string]string{"drone-nodes": ""},
 			},
-			want: map[string]string{"policy": ""},
+			want: map[string]string{"drone-nodes": ""},
 		},
 		{
 			desc: "test merge node_selector",
 			p: &Policy{
 				MergeNodeSelector: true,
-				NodeSelector:      map[string]string{"policy": ""},
+				NodeSelector:      map[string]string{"drone-nodes": ""},
 			},
 			want: map[string]string{
-				"policy": "",
-				"spec":   "",
+				"drone-nodes":      "",
+				"memory-optimized": "",
 			},
 		},
 	}
@@ -87,7 +87,7 @@ func TestNodeSelectors(t *testing.T) {
 	for _, test := range tests {
 		spec := &engine.Spec{
 			PodSpec: engine.PodSpec{
-				NodeSelector: map[string]string{"spec": ""},
+				NodeSelector: map[string]string{"memory-optimized": ""},
 			},
 		}
 

--- a/engine/policy/policy_test.go
+++ b/engine/policy/policy_test.go
@@ -15,14 +15,14 @@ func TestPodSpec(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		desc string
-		p    *Policy
-		spec engine.PodSpec
-		want engine.PodSpec
+		description string
+		policy      *Policy
+		spec        engine.PodSpec
+		want        engine.PodSpec
 	}{
 		{
-			desc: "test override tolerations",
-			p: &Policy{
+			description: "test override tolerations",
+			policy: &Policy{
 				Tolerations: []Toleration{{Key: "drone"}},
 			},
 			spec: engine.PodSpec{
@@ -33,8 +33,8 @@ func TestPodSpec(t *testing.T) {
 			},
 		},
 		{
-			desc: "test append tolerations",
-			p: &Policy{
+			description: "test append tolerations",
+			policy: &Policy{
 				AppendTolerations: true,
 				Tolerations:       []Toleration{{Key: "drone"}},
 			},
@@ -49,8 +49,8 @@ func TestPodSpec(t *testing.T) {
 			},
 		},
 		{
-			desc: "test override node_selector",
-			p: &Policy{
+			description: "test override node_selector",
+			policy: &Policy{
 				NodeSelector: map[string]string{"instancegroup": "drone"},
 			},
 			spec: engine.PodSpec{
@@ -61,8 +61,8 @@ func TestPodSpec(t *testing.T) {
 			},
 		},
 		{
-			desc: "test merge node_selector",
-			p: &Policy{
+			description: "test merge node_selector",
+			policy: &Policy{
 				MergeNodeSelector: true,
 				NodeSelector:      map[string]string{"instancegroup": "drone"},
 			},
@@ -80,10 +80,10 @@ func TestPodSpec(t *testing.T) {
 
 	for _, test := range tests {
 		got := &engine.Spec{PodSpec: test.spec}
-		test.p.Apply(got)
+		test.policy.Apply(got)
 
 		if !reflect.DeepEqual(test.want, got.PodSpec) {
-			t.Errorf("desc: %s\nexpected: %#v\ngot: %#v", test.desc, test.want, got.PodSpec)
+			t.Errorf("description: %s\nexpected: %#v\ngot: %#v", test.description, test.want, got.PodSpec)
 		}
 	}
 }

--- a/engine/policy/policy_test.go
+++ b/engine/policy/policy_test.go
@@ -64,14 +64,21 @@ func TestPodSpec(t *testing.T) {
 			description: "test merge node_selector",
 			policy: &Policy{
 				MergeNodeSelector: true,
-				NodeSelector:      map[string]string{"instancegroup": "drone"},
+				NodeSelector: map[string]string{
+					"default":       "drone",
+					"instancegroup": "drone",
+				},
 			},
 			spec: engine.PodSpec{
-				NodeSelector: map[string]string{"instanceclass": "memory-optimized"},
+				NodeSelector: map[string]string{
+					"instancegroup": "batch",
+					"instanceclass": "memory-optimized",
+				},
 			},
 			want: engine.PodSpec{
 				NodeSelector: map[string]string{
-					"instancegroup": "drone",
+					"default":       "drone",
+					"instancegroup": "batch",
 					"instanceclass": "memory-optimized",
 				},
 			},


### PR DESCRIPTION
There doesn't seem to be a way to define default Tolerations for drone pods the way you can with [NodeSelectors](https://docs.drone.io/runner/kubernetes/configuration/reference/drone-node-selector-default/).

Based on [this forum thread](https://community.harness.io/t/drone-runner-kube-default-toleration-and-node-selector/9546), it seems like runner Policy is the way to configure this. However, Policies can only override the Tolerations completely and doesn't really serve as a good way to define defaults.

As such, this PR suggests adding two new fields to the `Policy` config that allows for optional merging of `Tolerations` and `NodeSelector` policy with user-defined values.

This allows Drone admins to enforce a minimum policy to direct drone runner pods to specific nodes without stomping on the user supplied tolerations and nodeselector that might further instruct where k8s should schedule workloads.

Other possible implementations:
- Define new `DefaultTolerations` and `DefaultNodeSelector` policy fields instead of creating options to change the behavior of existing fields.
- Create a `DRONE_TOLERATIONS_DEFAULT` env var. However, this would probably need to be a json string input due to the complexity of Toleration configuration and is likely to yield a poor UX.