### PR TITLE
Test placeholder based on complete image.

### DIFF
--- a/engine/podwatcher/watcher.go
+++ b/engine/podwatcher/watcher.go
@@ -175,7 +175,7 @@ func (pw *PodWatcher) updateContainers(containers []containerInfo) {
 			continue
 		}
 
-		isPlaceholder := image.Match(cs.image, c.placeholder)
+		isPlaceholder := image.MatchTag(cs.image, c.placeholder)
 
 		// A running container with placeholder image (that we track, so present in pw.containerMap)
 		// usually means that Kubernetes is downloading the real step image in background.


### PR DESCRIPTION
Took me a long time to figure out what was going on here.

I have custom cloner and placeholder images. They are hosted on a private registry in the same image repository and differentiated by tags. For example,

```
example.com/drone:git
example.com/drone:placeholder
```

These images are multiplatform images based on `drone/git` and `drone/placeholder`.

Because these images differ only in tag, the check `image.Match` (which explicitly ignores tags) is detecting the cloner step  as having completed with the placeholder image -- i.e., the placeholder failed(!). This is detected as a step/framework error and the stage aborts.

I really have no idea why we would want to exclude tag here.