### PR TITLE
Add DRONE_STEP_NUMBER to environment variables

### DIFF
--- a/engine/compiler/step.go
+++ b/engine/compiler/step.go
@@ -18,7 +18,7 @@ import (
 
 const placeholderImage = "drone/placeholder:1"
 
-func createStep(spec *resource.Pipeline, src *resource.Step) *engine.Step {
+func createStep(src *resource.Step, num int64) *engine.Step {
 	dst := &engine.Step{
 		ID:           random(),
 		Name:         src.Name,
@@ -28,7 +28,7 @@ func createStep(spec *resource.Pipeline, src *resource.Step) *engine.Step {
 		Entrypoint:   src.Entrypoint,
 		Detach:       src.Detach,
 		DependsOn:    src.DependsOn,
-		Envs:         environ.Combine(convertStaticEnv(src.Environment), environ.StepName(src.Name)),
+		Envs:         environ.Combine(convertStaticEnv(src.Environment), environ.StepArgs(src.Name, num)),
 		IgnoreStderr: false,
 		IgnoreStdout: false,
 		Privileged:   src.Privileged,


### PR DESCRIPTION
We've noticed that https://docs.drone.io/pipeline/environment/reference/drone-step-number/ is not being set in the environment variables for pipelines run using this kube runner.

I believe the problem is this:

The pod environment is created in [engine.Setup](https://github.com/drone-runners/drone-runner-kube/blob/v1.0.0-rc.3/engine/engine_impl.go) from calls `toPod -> toContainers -> toContainer -> toEnv`. When this happens we don't yet have a StepNumber, we've only set the `DRONE_STEP_NAME`.

`engine.Setup` is called from [Execer.Exec](https://github.com/drone/runner-go/blob/v1.11.0/pipeline/runtime/execer.go#L70), and later in that function in a call to `Execer.exec` the `DRONE_STEP_NUMBER` is [supposed to set by on the step here](https://github.com/drone/runner-go/blob/v1.11.0/pipeline/runtime/execer.go#L225-L232). At this point the pod spec was already created, so this env var never makes it to the pod.

In this PR I've attempted to fix the problem by passing a step number in `Compiler.Compile` where the rest of the environment variables are set. I found that this is how #61 fixed the `DRONE_STEP_NAME` env variable. 

This fix is maybe not ideal because it's assuming the steps are not re-ordered in any way later, but it seems like it may be the only way to fix this problem without a larger change to where the pods specs are created.