### PR TITLE
fix: [CI-14780]: Fixing secret masking issue in Kube Runner

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -497,11 +497,7 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 		}
 
 		for _, s := range step.Secrets {
-			// if the secret was already fetched and stored in the
-			// secret map it can be skipped.
-			if _, ok := spec.Secrets[s.Name]; ok {
-				continue
-			}
+
 			secret, ok := c.findSecret(ctx, args, s.Name)
 			if ok {
 				s := &engine.Secret{

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -497,7 +497,12 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 		}
 
 		for _, s := range step.Secrets {
-
+			// if the secret was already fetched and stored in the
+			// secret map it can be skipped.
+			if _, ok := spec.Secrets[s.Name]; ok {
+				step.SpecSecrets = append(step.SpecSecrets, spec.Secrets[s.Name])
+				continue
+			}
 			secret, ok := c.findSecret(ctx, args, s.Name)
 			if ok {
 				s := &engine.Secret{

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/drone/drone-go v1.7.1
 	github.com/drone/envsubst v1.0.3
-	github.com/drone/runner-go v1.11.0
+	github.com/drone/runner-go v1.12.0
 	github.com/drone/signal v1.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/drone/drone-go v1.7.1/go.mod h1:fxCf9jAnXDZV1yDr0ckTuWd1intvcQwfJmTRp
 github.com/drone/envsubst v1.0.2/go.mod h1:bkZbnc/2vh1M12Ecn7EYScpI4YGYU0etwLJICOWi8Z0=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
 github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
-github.com/drone/runner-go v1.11.0 h1:zcn8Hmi0H1I4pxdJCauykG5teu3AH84Uw4WM7VrKlIM=
-github.com/drone/runner-go v1.11.0/go.mod h1:vu4pPPYDoeN6vdYQAY01GGGsAIW4aLganJNaa8Fx8zE=
+github.com/drone/runner-go v1.12.0 h1:zUjDj9ylsJ4n4Mvy4znddq/Z4EBzcUXzTltpzokKtgs=
+github.com/drone/runner-go v1.12.0/go.mod h1:vu4pPPYDoeN6vdYQAY01GGGsAIW4aLganJNaa8Fx8zE=
 github.com/drone/signal v1.0.0 h1:NrnM2M/4yAuU/tXs6RP1a1ZfxnaHwYkd0kJurA1p6uI=
 github.com/drone/signal v1.0.0/go.mod h1:S8t92eFT0g4WUgEc/LxG+LCuiskpMNsG0ajAMGnyZpc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
This PR fixing the secret masking issue in Drone kubernetes runner. Also we are upgrading runner-go to latest (v1.12) as in drone docker runner we are using latest.

Testing => 
Before
<img width="1640" alt="Screenshot 2024-11-21 at 10 13 33 PM" src="https://github.com/user-attachments/assets/f43dff2f-61b3-4f8f-adf5-6f39828b0d8e">
After
<img width="1725" alt="Screenshot 2024-11-21 at 10 13 47 PM" src="https://github.com/user-attachments/assets/9103d01f-a957-4ef0-893b-7c722ecd468c">
